### PR TITLE
Enable security stuff in Open API definition

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -33,6 +33,31 @@ specified as Flask application parameters:
 
    Default: ``'2.0'``
 
+Documenting Top-level Components
+------------------------------------------------------
+
+To add objects within the top-level components object, specify them in the
+API_SPEC_OPTIONS Flask application parameter:
+
+.. describe:: API_SPEC_OPTIONS
+
+   A dict to include in the top level components object of the Open API
+   definition. It is copied verbatim in the documentation.
+
+Here is an example on how to includes a Security Scheme Object:
+
+.. code-block:: python
+
+    app.config['API_SPEC_OPTIONS'] = {
+        'securityDefinitions': {
+            'MyToken': {
+                'type': 'apiKey',
+                'in': 'header',
+                'name': 'Authorization'
+            }
+        }
+    }
+
 Adding Documentation Information to the View Functions
 ------------------------------------------------------
 
@@ -97,15 +122,15 @@ for instance if it is provided by another Flask extension.)
 
 .. code-block:: python
 
-    # UUIDConverter is already known to the flask app as it is imported
+    # UUIDConverter is already known to the flask app as it is imported
     # from an extension that registers it.
     api.register_converter(UUIDConverter, 'string', 'UUID')
 
     @blp.route('/pets/{uuid:pet_id}')
         ...
 
-    # CustomConverter is defined in our application and must be registered
-    # in the Flask app. A name must be passed.
+    # CustomConverter is defined in our application and must be registered
+    # in the Flask app. A name must be passed.
     api.register_converter(CustomConverter, 'string', 'Custom',
                            name='custom')
 

--- a/flask_rest_api/blueprint.py
+++ b/flask_rest_api/blueprint.py
@@ -52,6 +52,7 @@ class Blueprint(FlaskBlueprint):
     def __init__(self, *args, **kwargs):
 
         self.description = kwargs.pop('description', '')
+        self.security = kwargs.pop('security', '')
 
         super().__init__(*args, **kwargs)
 
@@ -82,6 +83,8 @@ class Blueprint(FlaskBlueprint):
                     "Another doc is already registered for endpoint '{}' "
                     "method {}".format(endpoint, method_l.upper()))
             endpoint_doc[method_l] = doc
+            if self.security:
+                endpoint_doc[method_l]['security'] = self.security
 
         # MethodView (class)
         if isinstance(obj, MethodViewType):

--- a/flask_rest_api/spec/__init__.py
+++ b/flask_rest_api/spec/__init__.py
@@ -29,7 +29,8 @@ class APISpec(apispec.APISpec):
             title=app.name,
             version=app.config.get('API_VERSION', '1'),
             plugins=plugins,
-            openapi_version=app.config.get('OPENAPI_VERSION', '2.0')
+            openapi_version=app.config.get('OPENAPI_VERSION', '2.0'),
+            **app.config.get('API_SPEC_OPTIONS', {})
         )
         self._app = app
 


### PR DESCRIPTION
Allows to specify a swagger securitySchemes in the top level API doc
Also allows to specify the security scheme for a whole Blueprint at once rather than specifying the security='xxx' for each functions