### PR TITLE
Return 200 rather than 404 if pagination out of range

### DIFF
--- a/flask_rest_api/exceptions.py
+++ b/flask_rest_api/exceptions.py
@@ -15,10 +15,6 @@ class InvalidLocation(FlaskRestApiError):
     """Parameter location is not a valid location"""
 
 
-class PageOutOfRangeError(FlaskRestApiError):
-    """Requested page number out of page range"""
-
-
 class NotModified(wexc.HTTPException, FlaskRestApiError):
     """Resource was not modified (Etag is unchanged)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -244,7 +244,7 @@ class TestFullExample():
             list_etag = response.headers['ETag']
             assert len(response.json) == 0
             assert json.loads(response.headers['X-Pagination']) == {
-                'total': 0, 'total_pages': 0, 'page': 1}
+                'total': 0, 'total_pages': 0}
 
         # GET collection with correct ETag: Not modified
         with assert_counters(0, 1, 0, 1 if bp_schema == 'ETag schema' else 0):


### PR DESCRIPTION
On second thought, returning 200 seems better from a practical perspective.

For thoughts on this, see https://stackoverflow.com/questions/25724751/.

- This changes makes things more consistent with the "empty collection" case.
- It provides the client size of collection and available pages.
- It makes the code simpler...

Obviously, this is a breaking change.