### PR TITLE
Drop support for flask 0.x and register default error handler only for HTTPException

### DIFF
--- a/flask_rest_api/error_handler.py
+++ b/flask_rest_api/error_handler.py
@@ -1,7 +1,6 @@
 """Exception handler"""
 
-from werkzeug.exceptions import (
-    default_exceptions, HTTPException, InternalServerError)
+from werkzeug.exceptions import HTTPException, InternalServerError
 from flask import jsonify, current_app
 
 
@@ -11,15 +10,10 @@ class ErrorHandlerMixin:
     def _register_error_handlers(self):
         """Register error handlers in Flask app
 
-        This method registers an error handler for every exception code.
+        This method registers a default error handler for HTTPException.
         """
-        # On Flask versions older than 1.0, it is not possible to register a
-        # handler for all HTTPException at once, so we register the handler
-        # for each code explicitly.
-        # https://github.com/pallets/flask/issues/941#issuecomment-118975275
-        # This workaround can be dropped when dropping Flask<1.0 compatibility.
-        for code in default_exceptions:
-            self._app.register_error_handler(code, self.handle_http_exception)
+        self._app.register_error_handler(
+            HTTPException, self.handle_http_exception)
 
     def handle_http_exception(self, error):
         """Return error description and details in response body

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     },
     install_requires=[
         'werkzeug>=0.11',
-        'flask>=0.11',
+        'flask>=1.0',
         'marshmallow>=2.15.2',
         'webargs>=1.5.2',
         'apispec>=0.39.0',


### PR DESCRIPTION
Since Flask 1.0, it is now possible to register a error handler for generic `HTTPException` (https://github.com/pallets/flask/issues/941, https://github.com/pallets/flask/pull/2314).

Because this is not possible with Flask 0.x, the error handler is registered for all error codes as a workaround, which can mess with other extensions registering error handlers if flask-rest-api is initiated last.

This PR addresses this by only registering the error handler for `HTTPException` and dropping support for Flask 0.x. Now other extensions may register error handlers for specific exceptions or codes.