### PR TITLE
Allow OPENAPI_URL_PREFIX to be '/'

### DIFF
--- a/flask_rest_api/spec/__init__.py
+++ b/flask_rest_api/spec/__init__.py
@@ -66,7 +66,7 @@ class APISpec(apispec.APISpec):
 
 def _add_leading_slash(string):
     """Add leading slash to a string if there is None"""
-    return string if string[0] == '/' else '/' + string
+    return string if string.startswith('/') else '/' + string
 
 
 class DocBlueprintMixin:


### PR DESCRIPTION
If ` OPENAPI_URL_PREFIX == '/'`, `_add_leading_slash` is being called with an empty string and crashes with an IndexError.