### PR TITLE
Rework ETag feature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,17 +1,30 @@
 Changelog
 ---------
 
+0.11.0 (2018-11-09)
++++++++++++++++++++
+
+Features:
+
+- *Backwards-incompatible*: Rework of the ETag feature. It is now accesible
+  using dedicated ``Blueprint.etag`` decorator. ``check_etag`` and ``set_etag``
+  are methods of ``Blueprint`` and ``etag.INCLUDE_HEADERS`` is replaced with
+  ``Blueprint.ETAG_INCLUDE_HEADERS``. It is enabled by default (only on views
+  decorated with ``Blueprint.etag``) and disabled with ``ETAG_DISABLED``
+  application configuration parameter. ``is_etag_enabled`` is now private.
+
 0.10.0 (2018-10-24)
 +++++++++++++++++++
 
 Features:
 
 - *Backwards-incompatible*: Don't prefix all routes in the spec with
-  `APPLICATION_ROOT`. If using OpenAPI v2, set `APPLICATION_ROOT` as
-  `basePath`. If using OpenAPI v3, the user should specify `servers` manually.
-- *Backwards-incompatible*: In testing and debug modes, `verify_check_etag` not
-  only logs a warning but also raises `CheckEtagNotCalledError` if `check_etag`
-  is not called in a resource that needs it.
+  ``APPLICATION_ROOT``. If using OpenAPI v2, set ``APPLICATION_ROOT`` as
+  ``basePath``. If using OpenAPI v3, the user should specify ``servers``
+  manually.
+- *Backwards-incompatible*: In testing and debug modes, ``verify_check_etag``
+  not only logs a warning but also raises ``CheckEtagNotCalledError`` if
+  ``check_etag`` is not called in a resource that needs it.
 
 0.9.2 (2018-10-16)
 ++++++++++++++++++

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -22,6 +22,9 @@ Blueprint
     .. automethod:: arguments
     .. automethod:: response
     .. automethod:: paginate
+    .. automethod:: etag
+    .. automethod:: check_etag
+    .. automethod:: set_etag
 
 Pagination
 ==========
@@ -30,11 +33,3 @@ Pagination
     :members:
 .. autoclass:: flask_rest_api.pagination.PaginationParameters
     :members:
-
-ETag
-====
-
-.. autofunction:: flask_rest_api.etag.is_etag_enabled
-.. autofunction:: flask_rest_api.etag.is_etag_enabled_for_request
-.. autofunction:: flask_rest_api.etag.check_etag
-.. autofunction:: flask_rest_api.etag.set_etag

--- a/docs/etag.rst
+++ b/docs/etag.rst
@@ -14,9 +14,9 @@ The first case is mostly useful to limit the bandwidth usage, the latter
 addresses the case where two clients update a resource at the same time (known
 as the "*lost update problem*").
 
-The ETag featured is enabled with the `ETAG_ENABLED` application parameter. It
-can be disabled function-wise by passing `disable_etag=False` to the
-:meth:`Blueprint.response <Blueprint.response>` decorator.
+The ETag featured is available through the
+:meth:`Blueprint.etag <Blueprint.etag>` decorator. It can be disabled globally
+with the `ETAG_DISABLED` application parameter.
 
 `flask-rest-api` provides helpers to compute ETag, but ultimately, only the
 developer knows what data is relevant to use as ETag source, so there can be
@@ -29,23 +29,23 @@ The simplest case is when the ETag is computed using returned data, using the
 :class:`Schema <marshmallow.Schema>` that serializes the data.
 
 In this case, almost eveything is automatic. Only the call to
-:meth:`check_etag <etag.check_etag>` is manual.
+:meth:`Blueprint.check_etag <Blueprint.check_etag>` is manual.
 
 The :class:`Schema <marshmallow.Schema>` must be provided explicitly, even
 though it is the same as the response schema.
 
 .. code-block:: python
-    :emphasize-lines: 27,35
-
-    from flask_rest_api import check_etag
+    :emphasize-lines: 29,38
 
     @blp.route('/')
     class Pet(MethodView):
 
+        @blp.etag
         @blp.response(PetSchema(many=True))
         def get(self):
             return Pet.get()
 
+        @blp.etag
         @blp.arguments(PetSchema)
         @blp.response(PetSchema)
         def post(self, new_data):
@@ -54,24 +54,27 @@ though it is the same as the response schema.
     @blp.route('/<pet_id>')
     class PetById(MethodView):
 
+        @blp.etag
         @blp.response(PetSchema)
         def get(self, pet_id):
             return Pet.get_by_id(pet_id)
 
+        @blp.etag
         @blp.arguments(PetSchema)
         @blp.response(PetSchema)
         def put(self, update_data, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action and schema must be provided
-            check_etag(pet, PetSchema)
+            blp.check_etag(pet, PetSchema)
             pet.update(update_data)
             return pet
 
+        @blp.etag
         @blp.response(code=204)
         def delete(self, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action and schema must be provided
-            check_etag(pet, PetSchema)
+            blp.check_etag(pet, PetSchema)
             Pet.delete(pet_id)
 
 ETag Computed with API Response Data Using Another Schema
@@ -81,110 +84,126 @@ Sometimes, it is not possible to use the data returned by the view function as
 ETag data because it contains extra information that is irrelevant, like
 HATEOAS information, for instance.
 
-In this case, a specific ETag schema can be provided as ``etag_schema`` keyword
-argument to :meth:`Blueprint.response <Blueprint.response>`. Then, it does not
-need to be passed to :meth:`check_etag <etag.check_etag>`.
+In this case, a specific ETag schema should be provided to
+:meth:`Blueprint.etag <Blueprint.etag>`. Then, it does not need to be passed to
+:meth:`check_etag <Blueprint.check_etag>`.
 
 .. code-block:: python
-    :emphasize-lines: 7,12,19,24,28,32,36
-
-    from flask_rest_api import check_etag
+    :emphasize-lines: 4,9,18,23,29,33,38
 
     @blp.route('/')
     class Pet(MethodView):
 
-        @blp.response(
-            PetSchema(many=True), etag_schema=PetEtagSchema(many=True))
+        @blp.etag(PetEtagSchema(many=True))
+        @blp.response(PetSchema(many=True))
         def get(self):
             return Pet.get()
 
+        @blp.etag(PetEtagSchema)
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema, etag_schema=PetEtagSchema)
+        @blp.response(PetSchema)
         def post(self, new_pet):
             return Pet.create(**new_data)
 
     @blp.route('/<int:pet_id>')
     class PetById(MethodView):
 
-        @blp.response(PetSchema, etag_schema=PetEtagSchema)
+        @blp.etag(PetEtagSchema)
+        @blp.response(PetSchema)
         def get(self, pet_id):
             return Pet.get_by_id(pet_id)
 
+        @blp.etag(PetEtagSchema)
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema, etag_schema=PetEtagSchema)
+        @blp.response(PetSchema)
         def put(self, new_pet, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action and schema must be provided
-            check_etag(pet)
+            blp.check_etag(pet)
             pet.update(update_data)
             return pet
 
-        @blp.response(code=204, etag_schema=PetEtagSchema)
+        @blp.etag(PetEtagSchema)
+        @blp.response(code=204)
         def delete(self, pet_id):
             pet = self._get_pet(pet_id)
             # Check ETag is a manual action, ETag schema is used
-            check_etag(pet)
+            blp.check_etag(pet)
             Pet.delete(pet_id)
 
 ETag Computed on Arbitrary Data
 -------------------------------
 
 The ETag can also be computed from arbitrary data by calling
-:meth:`set_etag <etag.set_etag>` manually.
+:meth:`Blueprint.set_etag <Blueprint.set_etag>` manually.
 
 The example below illustrates this with no ETag schema, but it is also possible
-to pass an ETag schema to :meth:`set_etag <etag.set_etag>` and
-:meth:`check_etag <etag.check_etag>` or equivalently to
-:meth:`Blueprint.response <Blueprint.response>`.
+to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
+:meth:`check_etag <Blueprint.check_etag>` or equivalently to
+:meth:`Blueprint.etag <Blueprint.etag>`.
 
 .. code-block:: python
-    :emphasize-lines: 10,17,26,34,37,44
-
-    from flask_rest_api import check_etag, set_etag
+    :emphasize-lines: 4,9,12,17,23,27,30,36,39,42,47
 
     @blp.route('/')
     class Pet(MethodView):
 
+        @blp.etag
         @blp.response(PetSchema(many=True))
         def get(self):
             pets = Pet.get()
             # Compute ETag using arbitrary data
-            set_etag([pet.update_time for pet in pets])
+            blp.set_etag([pet.update_time for pet in pets])
             return pets
 
+        @blp.etag
         @blp.arguments(PetSchema)
         @blp.response(PetSchema)
         def post(self, new_data):
             # Compute ETag using arbitrary data
-            set_etag(new_data['update_time'])
+            blp.set_etag(new_data['update_time'])
             return Pet.create(**new_data)
 
     @blp.route('/<pet_id>')
     class PetById(MethodView):
 
+        @blp.etag
         @blp.response(PetSchema)
         def get(self, pet_id):
             # Compute ETag using arbitrary data
-            set_etag(new_data['update_time'])
+            blp.set_etag(new_data['update_time'])
             return Pet.get_by_id(pet_id)
 
+        @blp.etag
         @blp.arguments(PetSchema)
         @blp.response(PetSchema)
         def put(self, update_data, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action
-            check_etag(pet, ['update_time'])
+            blp.check_etag(pet, ['update_time'])
             pet.update(update_data)
             # Compute ETag using arbitrary data
-            set_etag(new_data['update_time'])
+            blp.set_etag(new_data['update_time'])
             return pet
 
+        @blp.etag
         @blp.response(code=204)
         def delete(self, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action
-            check_etag(pet, ['update_time'])
+            blp.check_etag(pet, ['update_time'])
             Pet.delete(pet_id)
+
+ETag not checked warning
+------------------------
+
+It is up to the developer to call
+:meth:`Blueprint.check_etag <Blueprint.check_etag>` in the view function. It
+can't be automatic.
+
+If ETag is enabled and :meth:`check_etag <Blueprint.check_etag>` is not called,
+a warning is logged at runtime. When in `DEBUG` or `TESTING` mode, an exception
+is raised.
 
 Include Headers Content in ETag
 -------------------------------
@@ -192,11 +211,5 @@ Include Headers Content in ETag
 When ETag is computed with response data, that data may contain headers. It is
 up to the developer to decide whether this data should be part of the ETag.
 
-By default, only pagination data is included in the ETag computation. The list
-of headers to include is defined as:
-
-.. code-block:: python
-
-    INCLUDE_HEADERS = ['X-Pagination']
-
-It can be changed globally by mutating ``flask_rest_api.etag.INCLUDE_HEADERS``.
+By default, only pagination header is included in the ETag computation. This
+can be changed by customizing `Blueprint.ETAG_INCLUDE_HEADERS`.

--- a/flask_rest_api/__init__.py
+++ b/flask_rest_api/__init__.py
@@ -4,7 +4,6 @@ from webargs.flaskparser import abort  # noqa
 
 from .spec import APISpec, DocBlueprintMixin
 from .blueprint import Blueprint  # noqa
-from .etag import check_etag, set_etag  # noqa
 from .pagination import Page  # noqa
 from .error_handler import ErrorHandlerMixin
 from .compat import APISPEC_VERSION_MAJOR

--- a/flask_rest_api/__init__.py
+++ b/flask_rest_api/__init__.py
@@ -4,7 +4,7 @@ from webargs.flaskparser import abort  # noqa
 
 from .spec import APISpec, DocBlueprintMixin
 from .blueprint import Blueprint  # noqa
-from .etag import is_etag_enabled, check_etag, set_etag  # noqa
+from .etag import check_etag, set_etag  # noqa
 from .pagination import Page  # noqa
 from .error_handler import ErrorHandlerMixin
 from .compat import APISPEC_VERSION_MAJOR

--- a/flask_rest_api/blueprint.py
+++ b/flask_rest_api/blueprint.py
@@ -36,6 +36,7 @@ from .utils import deepupdate, load_info_from_docstring
 from .arguments import ArgumentsMixin
 from .response import ResponseMixin
 from .pagination import PaginationMixin
+from .etag import EtagMixin
 from .exceptions import EndpointMethodDocAlreadyRegistedError
 from .compat import APISPEC_VERSION_MAJOR
 
@@ -46,7 +47,8 @@ HTTP_METHODS = [
 
 
 class Blueprint(
-        FlaskBlueprint, ArgumentsMixin, ResponseMixin, PaginationMixin):
+        FlaskBlueprint,
+        ArgumentsMixin, ResponseMixin, PaginationMixin, EtagMixin):
     """Blueprint that registers info in API documentation"""
 
     def __init__(self, *args, **kwargs):

--- a/flask_rest_api/etag.py
+++ b/flask_rest_api/etag.py
@@ -16,7 +16,7 @@ from .compat import MARSHMALLOW_VERSION_MAJOR
 
 def _is_etag_enabled():
     """Return True if ETag feature enabled application-wise"""
-    return current_app.config.get('ETAG_ENABLED', False)
+    return not current_app.config.get('ETAG_DISABLED', False)
 
 
 def _get_etag_ctx():

--- a/flask_rest_api/etag.py
+++ b/flask_rest_api/etag.py
@@ -14,13 +14,6 @@ from .utils import get_appcontext
 from .compat import MARSHMALLOW_VERSION_MAJOR
 
 
-METHODS_NEEDING_CHECK_ETAG = ['PUT', 'PATCH', 'DELETE']
-METHODS_ALLOWING_SET_ETAG = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH']
-
-# Can be mutated to specify which headers to use for ETag computation
-INCLUDE_HEADERS = ['X-Pagination']
-
-
 def _is_etag_enabled():
     """Return True if ETag feature enabled application-wise"""
     return current_app.config.get('ETAG_ENABLED', False)
@@ -31,138 +24,14 @@ def _get_etag_ctx():
     return get_appcontext()['etag']
 
 
-def _set_etag_schema(etag_schema):
-    _get_etag_ctx()['etag_schema'] = etag_schema
-
-
-def _get_etag_schema():
-    return _get_etag_ctx().get('etag_schema')
-
-
-def _generate_etag(etag_data, etag_schema=None, extra_data=None):
-    """Generate an ETag from data
-
-    etag_data: Data to use to compute ETag
-    etag_schema: Schema to dump data with before hashing
-    extra_data: Extra data to add before hashing
-
-    Typically, extra_data is used to add pagination metadata to the hash. It is
-    not dumped through the Schema.
-    """
-    if etag_schema is None:
-        raw_data = etag_data
-    else:
-        if isinstance(etag_schema, type):
-            etag_schema = etag_schema()
-        raw_data = etag_schema.dump(etag_data)
-        if MARSHMALLOW_VERSION_MAJOR < 3:
-            raw_data = raw_data[0]
-    if extra_data:
-        raw_data = (raw_data, extra_data)
-    # flask's json.dumps is needed here
-    # as vanilla json.dumps chokes on lazy_strings
-    data = json.dumps(raw_data, sort_keys=True)
-    return hashlib.sha1(bytes(data, 'utf-8')).hexdigest()
-
-
-def _check_precondition():
-    """Check If-Match header is there
-
-    Raise 428 if If-Match header missing
-
-    Called automatically for PUT, PATCH and DELETE methods
-    """
-    # TODO: other methods?
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
-    if request.method in METHODS_NEEDING_CHECK_ETAG and not request.if_match:
-        raise PreconditionRequired
-
-
-def check_etag(etag_data, etag_schema=None):
-    """Compare If-Match header with computed ETag
-
-    Raise 412 if If-Match-Header does not match.
-
-    Must be called from resource code to check ETag.
-
-    Unfortunately, there is no way to call it automatically. It is the
-    developer's responsability to do it. However, a warning is logged at
-    runtime if this function was not called.
-    """
-    if _is_etag_enabled():
-        etag_schema = etag_schema or _get_etag_schema()
-        new_etag = _generate_etag(etag_data, etag_schema)
-        _get_etag_ctx()['etag_checked'] = True
-        if new_etag not in request.if_match:
-            raise PreconditionFailed
-
-
-def _verify_check_etag():
-    """Verify check_etag was called in resource code
-
-    Log a warning if ETag is enabled but check_etag was not called in
-    resource code in a PUT, PATCH or DELETE method.
-
-    Raise CheckEtagNotCalledError when in debug or testing mode.
-
-    This is called automatically. It is meant to warn the developer about an
-    issue in his ETag management.
-    """
-    if request.method in METHODS_NEEDING_CHECK_ETAG:
-        if not _get_etag_ctx().get('etag_checked'):
-            message = (
-                'ETag enabled but not checked in endpoint {} on {} request.'
-                .format(request.endpoint, request.method))
-            app = current_app
-            app.logger.warning(message)
-            if app.debug or app.testing:
-                raise CheckEtagNotCalledError(message)
-
-
-def set_etag(etag_data, etag_schema=None):
-    """Set ETag for this response
-
-    Raise 304 if ETag identical to If-None-Match header
-
-    Can be called from resource code. If not called, ETag will be computed by
-    default from response data before sending response.
-
-    Logs a warning if called in a method other than GET, HEAD, POST, PUT, PATCH
-    """
-    if request.method not in METHODS_ALLOWING_SET_ETAG:
-        current_app.logger.warning(
-            'ETag cannot be set on {} request.'.format(request.method))
-    if _is_etag_enabled():
-        etag_schema = etag_schema or _get_etag_schema()
-        new_etag = _generate_etag(etag_data, etag_schema)
-        if new_etag in request.if_none_match:
-            raise NotModified
-        # Store ETag in AppContext to add it the the response headers later on
-        _get_etag_ctx()['etag'] = new_etag
-
-
-def _set_etag_in_response(response, etag_data, etag_schema):
-    """Set ETag in response object
-
-    Called automatically.
-
-    If no ETag data was computed using set_etag, it is computed here from
-    response data.
-    """
-    if request.method in METHODS_ALLOWING_SET_ETAG:
-        new_etag = _get_etag_ctx().get('etag')
-        # If no ETag data was manually provided, use response content
-        if new_etag is None:
-            headers = (response.headers.get(h) for h in INCLUDE_HEADERS)
-            extra_data = tuple(h for h in headers if h is not None)
-            new_etag = _generate_etag(etag_data, etag_schema, extra_data)
-            if new_etag in request.if_none_match:
-                raise NotModified
-        response.set_etag(new_etag)
-
-
 class EtagMixin:
     """Extend Blueprint to add ETag handling"""
+
+    METHODS_NEEDING_CHECK_ETAG = ['PUT', 'PATCH', 'DELETE']
+    METHODS_ALLOWING_SET_ETAG = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH']
+
+    # Headers to include in ETag computation
+    ETAG_INCLUDE_HEADERS = ['X-Pagination']
 
     def etag(self, etag_schema=None):
         """Decorator generating an endpoint response
@@ -200,16 +69,16 @@ class EtagMixin:
 
                 if etag_enabled:
                     # Check etag precondition
-                    _check_precondition()
+                    self._check_precondition()
                     # Store etag_schema in AppContext
-                    _set_etag_schema(etag_schema)
+                    _get_etag_ctx()['etag_schema'] = etag_schema
 
                 # Execute decorated function
                 resp = func(*args, **kwargs)
 
                 if etag_enabled:
                     # Verify check_etag was called in resource code if needed
-                    _verify_check_etag()
+                    self._verify_check_etag()
                     # Add etag value to response
                     # Pass data to use as ETag data if set_etag was not called
                     # If etag_schema is provided, pass raw result rather than
@@ -217,7 +86,7 @@ class EtagMixin:
                     etag_data = get_appcontext()[
                         'result_dump' if etag_schema is None else 'result_raw'
                     ]
-                    _set_etag_in_response(resp, etag_data, etag_schema)
+                    self._set_etag_in_response(resp, etag_data, etag_schema)
 
                 return resp
 
@@ -226,3 +95,126 @@ class EtagMixin:
         if view_func:
             return decorator(view_func)
         return decorator
+
+    @staticmethod
+    def _generate_etag(etag_data, etag_schema=None, extra_data=None):
+        """Generate an ETag from data
+
+        etag_data: Data to use to compute ETag
+        etag_schema: Schema to dump data with before hashing
+        extra_data: Extra data to add before hashing
+
+        Typically, extra_data is used to add pagination metadata to the hash.
+        It is not dumped through the Schema.
+        """
+        if etag_schema is None:
+            raw_data = etag_data
+        else:
+            if isinstance(etag_schema, type):
+                etag_schema = etag_schema()
+            raw_data = etag_schema.dump(etag_data)
+            if MARSHMALLOW_VERSION_MAJOR < 3:
+                raw_data = raw_data[0]
+        if extra_data:
+            raw_data = (raw_data, extra_data)
+        # flask's json.dumps is needed here
+        # as vanilla json.dumps chokes on lazy_strings
+        data = json.dumps(raw_data, sort_keys=True)
+        return hashlib.sha1(bytes(data, 'utf-8')).hexdigest()
+
+    def _check_precondition(self):
+        """Check If-Match header is there
+
+        Raise 428 if If-Match header missing
+
+        Called automatically for PUT, PATCH and DELETE methods
+        """
+        # TODO: other methods?
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
+        if (
+                request.method in self.METHODS_NEEDING_CHECK_ETAG and
+                not request.if_match
+        ):
+            raise PreconditionRequired
+
+    def check_etag(self, etag_data, etag_schema=None):
+        """Compare If-Match header with computed ETag
+
+        Raise 412 if If-Match-Header does not match.
+
+        Must be called from resource code to check ETag.
+
+        Unfortunately, there is no way to call it automatically. It is the
+        developer's responsability to do it. However, a warning is logged at
+        runtime if this function was not called.
+        """
+        if _is_etag_enabled():
+            etag_schema = etag_schema or _get_etag_ctx().get('etag_schema')
+            new_etag = self._generate_etag(etag_data, etag_schema)
+            _get_etag_ctx()['etag_checked'] = True
+            if new_etag not in request.if_match:
+                raise PreconditionFailed
+
+    def _verify_check_etag(self):
+        """Verify check_etag was called in resource code
+
+        Log a warning if ETag is enabled but check_etag was not called in
+        resource code in a PUT, PATCH or DELETE method.
+
+        Raise CheckEtagNotCalledError when in debug or testing mode.
+
+        This is called automatically. It is meant to warn the developer about
+        an issue in his ETag management.
+        """
+        if request.method in self.METHODS_NEEDING_CHECK_ETAG:
+            if not _get_etag_ctx().get('etag_checked'):
+                message = (
+                    'ETag not checked in endpoint {} on {} request.'
+                    .format(request.endpoint, request.method))
+                app = current_app
+                app.logger.warning(message)
+                if app.debug or app.testing:
+                    raise CheckEtagNotCalledError(message)
+
+    def set_etag(self, etag_data, etag_schema=None):
+        """Set ETag for this response
+
+        Raise 304 if ETag identical to If-None-Match header
+
+        Can be called from resource code. If not called, ETag will be computed
+        by default from response data before sending response.
+
+        Logs a warning if called in a method other than one of
+        GET, HEAD, POST, PUT, PATCH
+        """
+        if request.method not in self.METHODS_ALLOWING_SET_ETAG:
+            current_app.logger.warning(
+                'ETag cannot be set on {} request.'.format(request.method))
+        if _is_etag_enabled():
+            etag_schema = etag_schema or _get_etag_ctx().get('etag_schema')
+            new_etag = self._generate_etag(etag_data, etag_schema)
+            if new_etag in request.if_none_match:
+                raise NotModified
+            # Store ETag in AppContext to add it to response headers later on
+            _get_etag_ctx()['etag'] = new_etag
+
+    def _set_etag_in_response(self, response, etag_data, etag_schema):
+        """Set ETag in response object
+
+        Called automatically.
+
+        If no ETag data was computed using set_etag, it is computed here from
+        response data.
+        """
+        if request.method in self.METHODS_ALLOWING_SET_ETAG:
+            new_etag = _get_etag_ctx().get('etag')
+            # If no ETag data was manually provided, use response content
+            if new_etag is None:
+                headers = (
+                    response.headers.get(h) for h in self.ETAG_INCLUDE_HEADERS)
+                extra_data = tuple(h for h in headers if h is not None)
+                new_etag = self._generate_etag(
+                    etag_data, etag_schema, extra_data)
+                if new_etag in request.if_none_match:
+                    raise NotModified
+            response.set_etag(new_etag)

--- a/flask_rest_api/etag.py
+++ b/flask_rest_api/etag.py
@@ -50,6 +50,8 @@ class EtagMixin:
                 @blp.etag(EtagSchema)
                 def view_func(...):
                     ...
+
+        See :doc:`ETag <etag>`.
         """
         if etag_schema is None or isinstance(etag_schema, (type, Schema)):
             # Factory: @etag(), @etag(EtagSchema) or @etag(EtagSchema())

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -44,13 +44,15 @@ def app_with_etag(request, collection, schemas, app):
         @blp.route('/')
         class Resource(MethodView):
 
+            @blp.etag(DocEtagSchema(many=True))
             @blp.response(
-                DocSchema(many=True), etag_schema=DocEtagSchema(many=True))
+                DocSchema(many=True))
             def get(self):
                 return collection.items
 
+            @blp.etag(DocEtagSchema)
             @blp.arguments(DocSchema)
-            @blp.response(DocSchema, code=201, etag_schema=DocEtagSchema)
+            @blp.response(DocSchema, code=201)
             def post(self, new_item):
                 return collection.post(new_item)
 
@@ -63,18 +65,21 @@ def app_with_etag(request, collection, schemas, app):
                 except ItemNotFound:
                     abort(404)
 
-            @blp.response(DocSchema, etag_schema=DocEtagSchema)
+            @blp.etag(DocEtagSchema)
+            @blp.response(DocSchema)
             def get(self, item_id):
                 return self._get_item(item_id)
 
+            @blp.etag(DocEtagSchema)
             @blp.arguments(DocSchema)
-            @blp.response(DocSchema, etag_schema=DocEtagSchema)
+            @blp.response(DocSchema)
             def put(self, new_item, item_id):
                 item = self._get_item(item_id)
                 check_etag(item, DocEtagSchema)
                 return collection.put(item_id, new_item)
 
-            @blp.response(code=204, etag_schema=DocEtagSchema)
+            @blp.etag(DocEtagSchema)
+            @blp.response(code=204)
             def delete(self, item_id):
                 item = self._get_item(item_id)
                 check_etag(item, DocEtagSchema)
@@ -82,14 +87,15 @@ def app_with_etag(request, collection, schemas, app):
 
     else:
         @blp.route('/')
-        @blp.response(
-            DocSchema(many=True), etag_schema=DocEtagSchema(many=True))
+        @blp.etag(DocEtagSchema(many=True))
+        @blp.response(DocSchema(many=True))
         def get_resources():
             return collection.items
 
         @blp.route('/', methods=('POST',))
+        @blp.etag(DocEtagSchema)
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema, code=201, etag_schema=DocEtagSchema)
+        @blp.response(DocSchema, code=201)
         def post_resource(new_item):
             return collection.post(new_item)
 
@@ -100,23 +106,23 @@ def app_with_etag(request, collection, schemas, app):
                 abort(404)
 
         @blp.route('/<int:item_id>')
-        @blp.response(
-            DocSchema, etag_schema=DocEtagSchema)
+        @blp.etag(DocEtagSchema)
+        @blp.response(DocSchema)
         def get_resource(item_id):
             return _get_item(item_id)
 
         @blp.route('/<int:item_id>', methods=('PUT',))
+        @blp.etag(DocEtagSchema)
         @blp.arguments(DocSchema)
-        @blp.response(
-            DocSchema, etag_schema=DocEtagSchema)
+        @blp.response(DocSchema)
         def put_resource(new_item, item_id):
             item = _get_item(item_id)
             check_etag(item)
             return collection.put(item_id, new_item)
 
         @blp.route('/<int:item_id>', methods=('DELETE',))
-        @blp.response(
-            code=204, etag_schema=DocEtagSchema)
+        @blp.etag(DocEtagSchema)
+        @blp.response(code=204)
         def delete_resource(item_id):
             item = _get_item(item_id)
             check_etag(item)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,13 +9,7 @@ from flask.views import MethodView
 
 from flask_rest_api import Api, Blueprint, abort, Page
 
-from .conftest import AppConfig
 from .mocks import ItemNotFound
-
-
-class AppConfigFullExample(AppConfig):
-    """Basic config with ETag feature enabled"""
-    ETAG_ENABLED = True
 
 
 def implicit_data_and_schema_etag_blueprint(collection, schemas):
@@ -231,7 +225,6 @@ def blueprint_fixture(request, collection, schemas):
 
 class TestFullExample():
 
-    @pytest.mark.parametrize('app', [AppConfigFullExample], indirect=True)
     def test_examples(self, app, blueprint_fixture, schemas):
 
         blueprint, bp_schema = blueprint_fixture

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,7 +7,7 @@ import pytest
 
 from flask.views import MethodView
 
-from flask_rest_api import Api, Blueprint, abort, check_etag, set_etag, Page
+from flask_rest_api import Api, Blueprint, abort, Page
 
 from .conftest import AppConfig
 from .mocks import ItemNotFound
@@ -64,7 +64,7 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
         def put(self, new_item, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action and schema must be provided
-            check_etag(item, DocSchema)
+            blp.check_etag(item, DocSchema)
             return collection.put(item_id, new_item)
 
         @blp.etag
@@ -72,7 +72,7 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
         def delete(self, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action and schema must be provided
-            check_etag(item, DocSchema)
+            blp.check_etag(item, DocSchema)
             collection.delete(item_id)
 
     return blp
@@ -129,7 +129,7 @@ def implicit_data_explicit_schema_etag_blueprint(collection, schemas):
         def put(self, new_item, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action, ETag schema is used
-            check_etag(item)
+            blp.check_etag(item)
             new_item = collection.put(item_id, new_item)
             return new_item
 
@@ -138,7 +138,7 @@ def implicit_data_explicit_schema_etag_blueprint(collection, schemas):
         def delete(self, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action, ETag schema is used
-            check_etag(item)
+            blp.check_etag(item)
             collection.delete(item_id)
 
     return blp
@@ -176,7 +176,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
         @blp.response(DocSchema)
         def post(self, new_item):
             # Compute ETag using arbitrary data and no schema
-            set_etag(new_item['db_field'])
+            blp.set_etag(new_item['db_field'])
             return collection.post(new_item)
 
     @blp.route('/<int:item_id>')
@@ -193,7 +193,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
         def get(self, item_id):
             item = self._get_item(item_id)
             # Compute ETag using arbitrary data and no schema
-            set_etag(item['db_field'])
+            blp.set_etag(item['db_field'])
             return item
 
         @blp.etag
@@ -202,10 +202,10 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
         def put(self, new_item, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action, no shema used
-            check_etag(item['db_field'])
+            blp.check_etag(item['db_field'])
             new_item = collection.put(item_id, new_item)
             # Compute ETag using arbitrary data and no schema
-            set_etag(new_item['db_field'])
+            blp.set_etag(new_item['db_field'])
             return new_item
 
         @blp.etag
@@ -213,7 +213,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
         def delete(self, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action, no shema used
-            check_etag(item['db_field'])
+            blp.check_etag(item['db_field'])
             collection.delete(item_id)
 
     return blp

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -32,13 +32,13 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
     @blp.route('/')
     class Resource(MethodView):
 
-        @blp.etag()
+        @blp.etag
         @blp.response(DocSchema(many=True))
         @blp.paginate(Page)
         def get(self):
             return collection.items
 
-        @blp.etag()
+        @blp.etag
         @blp.arguments(DocSchema)
         @blp.response(DocSchema)
         def post(self, new_item):
@@ -53,12 +53,12 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
             except ItemNotFound:
                 abort(404)
 
-        @blp.etag()
+        @blp.etag
         @blp.response(DocSchema)
         def get(self, item_id):
             return self._get_item(item_id)
 
-        @blp.etag()
+        @blp.etag
         @blp.arguments(DocSchema)
         @blp.response(DocSchema)
         def put(self, new_item, item_id):
@@ -67,7 +67,7 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
             check_etag(item, DocSchema)
             return collection.put(item_id, new_item)
 
-        @blp.etag()
+        @blp.etag
         @blp.response(code=204)
         def delete(self, item_id):
             item = self._get_item(item_id)
@@ -159,7 +159,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
     @blp.route('/')
     class Resource(MethodView):
 
-        @blp.etag()
+        @blp.etag
         @blp.response(DocSchema(many=True))
         @blp.paginate()
         def get(self, pagination_parameters):
@@ -171,7 +171,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
                 pagination_parameters.last_item + 1
             ]
 
-        @blp.etag()
+        @blp.etag
         @blp.arguments(DocSchema)
         @blp.response(DocSchema)
         def post(self, new_item):
@@ -188,7 +188,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
             except ItemNotFound:
                 abort(404)
 
-        @blp.etag()
+        @blp.etag
         @blp.response(DocSchema)
         def get(self, item_id):
             item = self._get_item(item_id)
@@ -196,7 +196,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
             set_etag(item['db_field'])
             return item
 
-        @blp.etag()
+        @blp.etag
         @blp.arguments(DocSchema)
         @blp.response(DocSchema)
         def put(self, new_item, item_id):
@@ -208,7 +208,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
             set_etag(new_item['db_field'])
             return new_item
 
-        @blp.etag()
+        @blp.etag
         @blp.response(code=204)
         def delete(self, item_id):
             item = self._get_item(item_id)


### PR DESCRIPTION
Extract ETag feature in a separate mixin to decouple it from response marshmaling.

Main changes:

- Etag is now managed from a new `@etag` decorator.
- `check_etag` and `set_etag` are methods of `EtagMixin`, therefore of `Blueprint`.
- No need to use `disable_etag_for_request`: just don't use `@etag` decorator.
- List of headers to include in ETag computation is configurable in `Blueprint.ETAG_INCLUDE_HEADERS`.

TODO:

- [x] Changelog
- [x] Docs
- [x] Replace `ETAG_ENABLED` config variable with `ETAG_DISABLED` (_à la_ [flask-login](https://flask-login.readthedocs.io/en/latest/))?