### PR TITLE
Prevent registering several times the same endpoint

### DIFF
--- a/flask_rest_api/exceptions.py
+++ b/flask_rest_api/exceptions.py
@@ -7,10 +7,6 @@ class FlaskRestApiError(Exception):
     """Generic flask-rest-api exception"""
 
 
-class EndpointMethodDocAlreadyRegistedError(FlaskRestApiError):
-    """Documentation already registered for this endpoint/method couple"""
-
-
 class InvalidLocationError(FlaskRestApiError):
     """Parameter location is not a valid location"""
 


### PR DESCRIPTION
Registering several routes / view functions for the same endpoint leads to all kinds of trouble.

The user may specify an optional endpoint name when calling `Blueprint.route` so he can avoid this. But if he does not, a unique endpoint name is provided.

This change allows to remove a few awkward statements that were meant to account for the multiple rules per endpoint case.