### PR TITLE
Allow adding definitions before registering app

### DIFF
--- a/flask_rest_api/error_handler.py
+++ b/flask_rest_api/error_handler.py
@@ -7,13 +7,12 @@ from flask import jsonify, current_app
 class ErrorHandlerMixin:
     """Extend Api to manage error handling."""
 
-    def _register_error_handlers(self):
+    def _register_error_handlers(self, app):
         """Register error handlers in Flask app
 
         This method registers a default error handler for HTTPException.
         """
-        self._app.register_error_handler(
-            HTTPException, self.handle_http_exception)
+        app.register_error_handler(HTTPException, self.handle_http_exception)
 
     def handle_http_exception(self, error):
         """Return error description and details in response body

--- a/flask_rest_api/spec/__init__.py
+++ b/flask_rest_api/spec/__init__.py
@@ -72,14 +72,14 @@ def _add_leading_slash(string):
 class DocBlueprintMixin:
     """Extend Api to serve the spec in a dedicated blueprint."""
 
-    def _register_doc_blueprint(self):
+    def _register_doc_blueprint(self, app):
         """Register a blueprint in the application to expose the spec
 
         Doc Blueprint contains routes to
         - json spec file
         - spec UI (ReDoc, Swagger UI).
         """
-        api_url = self._app.config.get('OPENAPI_URL_PREFIX', None)
+        api_url = app.config.get('OPENAPI_URL_PREFIX', None)
         if api_url is not None:
             blueprint = flask.Blueprint(
                 'api-docs',
@@ -87,18 +87,32 @@ class DocBlueprintMixin:
                 url_prefix=_add_leading_slash(api_url),
                 template_folder='./templates',
             )
-            # Serve json spec at 'url_prefix/openapi.json' by default
-            json_path = self._app.config.get(
-                'OPENAPI_JSON_PATH', 'openapi.json')
-            blueprint.add_url_rule(
-                _add_leading_slash(json_path),
-                endpoint='openapi_json',
-                view_func=self._openapi_json)
-            self._register_redoc_rule(blueprint)
-            self._register_swagger_ui_rule(blueprint)
-            self._app.register_blueprint(blueprint)
+            self._register_openapi_json_rule(app, blueprint)
+            self._register_redoc_rule(app, blueprint)
+            self._register_swagger_ui_rule(app, blueprint)
+            app.register_blueprint(blueprint)
 
-    def _register_redoc_rule(self, blueprint):
+    def _register_openapi_json_rule(self, app, blueprint):
+        """Serve json spec file"""
+        json_path = app.config.get('OPENAPI_JSON_PATH', 'openapi.json')
+
+        def openapi_json():
+            """Serve JSON spec file"""
+            # We don't use Flask.jsonify here as it would sort the keys
+            # alphabetically while we want to preserve the order.
+            # We use current_app as the response class could be changed
+            # after Api is initialized.
+            return current_app.response_class(
+                json.dumps(self._specs[app].to_dict(), indent=2),
+                mimetype='application/json')
+
+        blueprint.add_url_rule(
+            _add_leading_slash(json_path),
+            endpoint='openapi_json',
+            view_func=openapi_json)
+
+    @staticmethod
+    def _register_redoc_rule(app, blueprint):
         """Register ReDoc rule
 
         The ReDoc script URL can be specified as OPENAPI_REDOC_URL.
@@ -115,12 +129,12 @@ class DocBlueprintMixin:
 
         OPENAPI_REDOC_VERSION is ignored when OPENAPI_REDOC_URL is passed.
         """
-        redoc_path = self._app.config.get('OPENAPI_REDOC_PATH')
+        redoc_path = app.config.get('OPENAPI_REDOC_PATH')
         if redoc_path is not None:
-            redoc_url = self._app.config.get('OPENAPI_REDOC_URL')
+            redoc_url = app.config.get('OPENAPI_REDOC_URL')
             if redoc_url is None:
                 # TODO: default to 'next' when ReDoc 2.0.0 is released.
-                redoc_version = self._app.config.get(
+                redoc_version = app.config.get(
                     'OPENAPI_REDOC_VERSION', 'latest')
                 # latest or v1.x -> Redoc GitHub CDN
                 if redoc_version == 'latest' or redoc_version.startswith('v1'):
@@ -132,13 +146,19 @@ class DocBlueprintMixin:
                     redoc_url = (
                         'https://cdn.jsdelivr.net/npm/redoc@'
                         '{}/bundles/redoc.standalone.js'.format(redoc_version))
-            self._redoc_url = redoc_url
+
+            def openapi_redoc():
+                """Expose OpenAPI spec with ReDoc"""
+                return flask.render_template(
+                    'redoc.html', title=app.name, redoc_url=redoc_url)
+
             blueprint.add_url_rule(
                 _add_leading_slash(redoc_path),
                 endpoint='openapi_redoc',
-                view_func=self._openapi_redoc)
+                view_func=openapi_redoc)
 
-    def _register_swagger_ui_rule(self, blueprint):
+    @staticmethod
+    def _register_swagger_ui_rule(app, blueprint):
         """Register Swagger UI rule
 
         The Swagger UI scripts base URL can be specified as
@@ -154,47 +174,34 @@ class DocBlueprintMixin:
         OPENAPI_SWAGGER_UI_SUPPORTED_SUBMIT_METHODS specifes the methods for
         which the 'Try it out!' feature is enabled.
         """
-        swagger_ui_path = self._app.config.get('OPENAPI_SWAGGER_UI_PATH')
+        swagger_ui_path = app.config.get('OPENAPI_SWAGGER_UI_PATH')
         if swagger_ui_path is not None:
-            swagger_ui_url = self._app.config.get('OPENAPI_SWAGGER_UI_URL')
+            swagger_ui_url = app.config.get('OPENAPI_SWAGGER_UI_URL')
             if swagger_ui_url is None:
-                swagger_ui_version = self._app.config.get(
+                swagger_ui_version = app.config.get(
                     'OPENAPI_SWAGGER_UI_VERSION')
                 if swagger_ui_version is not None:
                     swagger_ui_url = (
                         'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/'
                         '{}/'.format(swagger_ui_version))
             if swagger_ui_url is not None:
-                self._swagger_ui_url = swagger_ui_url
-                self._swagger_ui_supported_submit_methods = (
-                    self._app.config.get(
+                swagger_ui_supported_submit_methods = (
+                    app.config.get(
                         'OPENAPI_SWAGGER_UI_SUPPORTED_SUBMIT_METHODS',
                         ['get', 'put', 'post', 'delete', 'options',
                          'head', 'patch', 'trace'])
                 )
+
+                def openapi_swagger_ui():
+                    """Expose OpenAPI spec with Swagger UI"""
+                    return flask.render_template(
+                        'swagger_ui.html', title=app.name,
+                        swagger_ui_url=swagger_ui_url,
+                        swagger_ui_supported_submit_methods=(
+                            swagger_ui_supported_submit_methods)
+                    )
+
                 blueprint.add_url_rule(
                     _add_leading_slash(swagger_ui_path),
                     endpoint='openapi_swagger_ui',
-                    view_func=self._openapi_swagger_ui)
-
-    def _openapi_json(self):
-        """Serve JSON spec file"""
-        # We don't use Flask.jsonify here as it would sort the keys
-        # alphabetically while we want to preserve the order.
-        return current_app.response_class(
-            json.dumps(self.spec.to_dict(), indent=2),
-            mimetype='application/json')
-
-    def _openapi_redoc(self):
-        """Expose OpenAPI spec with ReDoc"""
-        return flask.render_template(
-            'redoc.html', title=self._app.name, redoc_url=self._redoc_url)
-
-    def _openapi_swagger_ui(self):
-        """Expose OpenAPI spec with Swagger UI"""
-        return flask.render_template(
-            'swagger_ui.html', title=self._app.name,
-            swagger_ui_url=self._swagger_ui_url,
-            swagger_ui_supported_submit_methods=(
-                self._swagger_ui_supported_submit_methods)
-        )
+                    view_func=openapi_swagger_ui)

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -39,7 +39,7 @@ class TestArgsParser():
             def get(self, args):
                 return jsonify(args)
 
-        api.register_blueprint(blp)
+        api.register_blueprint(app, blp)
 
         res = app.test_client().get('/test/', query_string={
             'user.first_name': 'Chuck', 'user.last_name': 'Norris'})

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -48,8 +48,8 @@ class TestBlueprint():
             def func():
                 """Dummy view func"""
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
         get = spec['paths']['/test/']['get']
         if openapi_location != 'body' or openapi_version == '2.0':
             loc = get['parameters'][0]['in']
@@ -87,8 +87,8 @@ class TestBlueprint():
             def func():
                 pass
 
-        api.register_blueprint(blp)
-        get = api.spec.to_dict()['paths']['/test/']['get']
+        api.register_blueprint(app, blp)
+        get = api._specs[app].to_dict()['paths']['/test/']['get']
         if location == 'json':
             if openapi_version == '2.0':
                 parameters = get['parameters']
@@ -130,8 +130,8 @@ class TestBlueprint():
                 'query_args': query_args,
             })
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
 
         # Check parameters are documented
         parameters = spec['paths']['/test/']['post']['parameters']
@@ -177,8 +177,8 @@ class TestBlueprint():
         def get(item_id):
             pass
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
         params = spec['paths']['/test/{item_id}']['get']['parameters']
         assert len(params) == 1
         if openapi_version == '2.0':
@@ -217,9 +217,9 @@ class TestBlueprint():
         def many_true():
             pass
 
-        api.register_blueprint(blp)
+        api.register_blueprint(app, blp)
 
-        paths = api.spec.to_dict()['paths']
+        paths = api._specs[app].to_dict()['paths']
 
         response = paths['/test/schema_many_false']['get']['responses']['200']
         if openapi_version == '2.0':
@@ -249,8 +249,8 @@ class TestBlueprint():
         def func():
             """Dummy view func"""
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
 
         # Check parameters are documented
         parameters = spec['paths']['/test/']['get']['parameters']
@@ -285,8 +285,8 @@ class TestBlueprint():
         def view_func():
             pass
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
         path = spec['paths']['/test/']
         for method in ('put', 'patch', ):
             assert path[method]['summary'] == 'Dummy func'
@@ -307,8 +307,8 @@ class TestBlueprint():
             def patch(self):
                 pass
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
         path = spec['paths']['/test/']
         for method in ('put', 'patch', ):
             assert path[method]['summary'] == 'Dummy {}'.format(method)
@@ -324,8 +324,8 @@ class TestBlueprint():
         def view_func():
             pass
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
         path = spec['paths']['/test/']
         assert path['get']['summary'] == 'Dummy func'
         assert path['get']['description'] == 'Do dummy stuff'
@@ -352,8 +352,8 @@ class TestBlueprint():
             def get(self):
                 pass
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
         get = spec['paths']['/test/']['get']
         assert get['requestBody']['content']['application/json'][
             'example'] == {'test': 123}
@@ -386,8 +386,8 @@ class TestBlueprint():
                 Docstring patch description
                 """
 
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
+        api.register_blueprint(app, blp)
+        spec = api._specs[app].to_dict()
         path = spec['paths']['/test/']
 
         assert path['get']['summary'] == 'Docstring get summary'
@@ -434,8 +434,8 @@ class TestBlueprint():
             def get(self):
                 pass
 
-        api.register_blueprint(blp)
-        methods = list(api.spec.to_dict()['paths']['/test/'].keys())
+        api.register_blueprint(app, blp)
+        methods = list(api._specs[app].to_dict()['paths']['/test/'].keys())
         assert methods == [m.lower() for m in http_methods]
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.1'))
@@ -463,8 +463,8 @@ class TestBlueprint():
             def func():
                 pass
 
-        api.register_blueprint(blp)
-        paths = api.spec.to_dict()['paths']
+        api.register_blueprint(app, blp)
+        paths = api._specs[app].to_dict()['paths']
 
         assert 'get' in paths['/test/route_1']
         assert 'get' in paths['/test/route_2']

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -122,7 +122,7 @@ def app_with_etag(request, collection, schemas, app):
             del collection.items[collection.items.index(item)]
 
     api = Api(app)
-    api.register_blueprint(blp)
+    api.register_blueprint(app, blp)
 
     return app
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -227,10 +227,10 @@ class TestFullExample():
 
     def test_examples(self, app, blueprint_fixture, schemas):
 
-        blueprint, bp_schema = blueprint_fixture
+        blp, bp_schema = blueprint_fixture
 
         api = Api(app)
-        api.register_blueprint(blueprint)
+        api.register_blueprint(app, blp)
 
         client = app.test_client()
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -105,7 +105,7 @@ def app_fixture(request, collection, schemas, app):
     blp_factory, as_method_view, custom_params = request.param
     blueprint = blp_factory(collection, schemas, as_method_view, custom_params)
     api = Api(app)
-    api.register_blueprint(blueprint)
+    api.register_blueprint(app, blueprint)
     return namedtuple('AppFixture', ('client', 'custom_params'))(
         app.test_client(), custom_params)
 
@@ -139,7 +139,7 @@ class TestPagination():
             pagination_parameters.item_count = 2
             return [1, 2]
 
-        api.register_blueprint(blp)
+        api.register_blueprint(app, blp)
         client = app.test_client()
         response = client.get('/test/')
         assert response.status_code == 200
@@ -168,7 +168,7 @@ class TestPagination():
             # pagination_parameters.item_count = 2
             return [1, 2]
 
-        api.register_blueprint(blp)
+        api.register_blueprint(app, blp)
         client = app.test_client()
 
         with mock.patch.object(app.logger, 'warning') as mock_warning:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -16,7 +16,7 @@ class TestAPISpec():
     def test_apispec_sets_produces_consumes(self, app, openapi_version):
         app.config['OPENAPI_VERSION'] = openapi_version
         api = Api(app)
-        spec = api.spec.to_dict()
+        spec = api._specs[app].to_dict()
 
         if openapi_version == '2.0':
             assert spec['produces'] == ['application/json', ]
@@ -160,7 +160,7 @@ class TestAPISpecServeDocs():
         # Add ordered stuff. This is invalid, but it will do for the test.
         paths = OrderedDict(
             [('/path_{}'.format(i), str(i)) for i in range(20)])
-        api.spec._paths = paths
+        api._specs[app]._paths = paths
 
         response_json_docs = client.get('/api-docs/openapi.json')
         assert response_json_docs.status_code == 200


### PR DESCRIPTION
Based on https://github.com/Nobatek/flask-rest-api/pull/28.

With current code, `definition` decorator only works if an app is already registered. This means the schema (and therefore the views) must be imported at app init time. Worse, if multiple apps are used, it will only work if definitions are added after all apps are initiated.

This change allows definitions to be registered before apps are initialized, i.e. at application import time, rather than init time. It allows a single file app with a `create_app` function.

 It keeps the old behaviour, so definitions can still be added after apps are initialized. This is mandatory if the `init_app` pattern is not used (if calling `Api(app)`), for instance.

TODO:

- [ ] #28 
- [ ] Changelog
- [ ] Documentation ?