### PR TITLE
Allow view functions to return tuple or Response class

### DIFF
--- a/flask_rest_api/etag.py
+++ b/flask_rest_api/etag.py
@@ -85,9 +85,12 @@ class EtagMixin:
                     # Pass data to use as ETag data if set_etag was not called
                     # If etag_schema is provided, pass raw result rather than
                     # dump, as the dump needs to be done using etag_schema
-                    etag_data = get_appcontext()[
-                        'result_dump' if etag_schema is None else 'result_raw'
-                    ]
+                    # If 'result_dump'/'result_raw' is not in appcontext,
+                    # the Etag must have been set manually. Just pass None.
+                    etag_data = get_appcontext().get(
+                        'result_dump' if etag_schema is None else 'result_raw',
+                        None
+                    )
                     self._set_etag_in_response(resp, etag_data, etag_schema)
 
                 return resp

--- a/flask_rest_api/pagination.py
+++ b/flask_rest_api/pagination.py
@@ -18,7 +18,7 @@ from flask import request, current_app
 import marshmallow as ma
 from webargs.flaskparser import FlaskParser
 
-from .utils import get_appcontext, unpack_tuple_response
+from .utils import unpack_tuple_response
 from .compat import MARSHMALLOW_VERSION_MAJOR
 
 
@@ -183,7 +183,9 @@ class PaginationMixin:
                         page_header = self._make_pagination_header(
                             page_params.page, page_params.page_size,
                             page_params.item_count)
-                        get_appcontext()['headers'][
+                        if headers is None:
+                            headers = {}
+                        headers[
                             self.PAGINATION_HEADER_FIELD_NAME] = page_header
 
                 return result, status, headers

--- a/flask_rest_api/pagination.py
+++ b/flask_rest_api/pagination.py
@@ -18,7 +18,7 @@ from flask import request, current_app
 import marshmallow as ma
 from webargs.flaskparser import FlaskParser
 
-from .utils import get_appcontext
+from .utils import get_appcontext, unpack_tuple_response
 from .compat import MARSHMALLOW_VERSION_MAJOR
 
 
@@ -166,7 +166,8 @@ class PaginationMixin:
                     kwargs['pagination_parameters'] = page_params
 
                 # Execute decorated function
-                result = func(*args, **kwargs)
+                result, status, headers = unpack_tuple_response(
+                    func(*args, **kwargs))
 
                 # Post pagination: use pager class to paginate the result
                 if pager is not None:
@@ -185,7 +186,7 @@ class PaginationMixin:
                         get_appcontext()['headers'][
                             self.PAGINATION_HEADER_FIELD_NAME] = page_header
 
-                return result
+                return result, status, headers
 
             return wrapper
 

--- a/flask_rest_api/response.py
+++ b/flask_rest_api/response.py
@@ -66,7 +66,6 @@ class ResponseMixin:
 
                 # Build response
                 resp = jsonify(self._prepare_response_content(result_dump))
-                resp.headers.extend(appcontext['headers'])
                 set_status_and_headers_in_response(resp, status, headers)
                 if status is None:
                     resp.status_code = code

--- a/flask_rest_api/utils.py
+++ b/flask_rest_api/utils.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 from collections.abc import Mapping
 
+from werkzeug.datastructures import Headers
 from flask import _app_ctx_stack
 from apispec.utils import trim_docstring, dedent
 
@@ -62,3 +63,33 @@ def load_info_from_docstring(docstring):
     if description_lines:
         info['description'] = dedent('\n'.join(description_lines))
     return info
+
+
+# Copied from flask
+def unpack_tuple_response(rv):
+    """Unpack a flask Response tuple"""
+
+    status = headers = None
+
+    # unpack tuple returns
+    if isinstance(rv, tuple):
+        len_rv = len(rv)
+
+        # a 3-tuple is unpacked directly
+        if len_rv == 3:
+            rv, status, headers = rv
+        # decide if a 2-tuple has status or headers
+        elif len_rv == 2:
+            if isinstance(rv[1], (Headers, dict, tuple, list)):
+                rv, headers = rv
+            else:
+                rv, status = rv
+        # other sized tuples are not allowed
+        else:
+            raise TypeError(
+                'The view function did not return a valid response tuple.'
+                ' The tuple must have the form (body, status, headers),'
+                ' (body, status), or (body, headers).'
+            )
+
+    return rv, status, headers

--- a/flask_rest_api/utils.py
+++ b/flask_rest_api/utils.py
@@ -93,3 +93,14 @@ def unpack_tuple_response(rv):
             )
 
     return rv, status, headers
+
+
+def set_status_and_headers_in_response(response, status, headers):
+    """Set status and headers in flask Reponse object"""
+    if headers:
+        response.headers.extend(headers)
+    if status is not None:
+        if isinstance(status, int):
+            response.status_code = status
+        else:
+            response.status = status

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -604,3 +604,22 @@ class TestBlueprint():
         assert response.headers['X-header'] == 'test'
         response = client.get('/test/response_wrong_tuple')
         assert response.status_code == 500
+
+    def test_blueprint_response_response_object(self, app, schemas):
+        api = Api(app)
+        blp = Blueprint('test', __name__, url_prefix='/test')
+        client = app.test_client()
+
+        @blp.route('/response')
+        # Schema is ignored when response object is returned
+        @blp.response(schemas.DocSchema, code=200)
+        def func_response():
+            return jsonify({}), 201, {'X-header': 'test'}
+
+        api.register_blueprint(blp)
+
+        response = client.get('/test/response')
+        assert response.status_code == 201
+        assert response.status == '201 CREATED'
+        assert response.json == {}
+        assert response.headers['X-header'] == 'test'

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -481,3 +481,73 @@ class TestBlueprint():
 
         assert 'get' in paths['/test/route_1']
         assert 'get' in paths['/test/route_2']
+
+    def test_blueprint_response_tuple(self, app):
+        api = Api(app)
+        blp = Blueprint('test', __name__, url_prefix='/test')
+        client = app.test_client()
+
+        @blp.route('/response')
+        @blp.response()
+        def func_response():
+            return {}
+
+        @blp.route('/response_code_int')
+        @blp.response()
+        def func_response_code_int():
+            return {}, 201
+
+        @blp.route('/response_code_str')
+        @blp.response()
+        def func_response_code_str():
+            return {}, '201 CREATED'
+
+        @blp.route('/response_headers')
+        @blp.response()
+        def func_response_headers():
+            return {}, {'X-header': 'test'}
+
+        @blp.route('/response_code_int_headers')
+        @blp.response()
+        def func_response_code_int_headers():
+            return {}, 201, {'X-header': 'test'}
+
+        @blp.route('/response_code_str_headers')
+        @blp.response()
+        def func_response_code_str_headers():
+            return {}, '201 CREATED', {'X-header': 'test'}
+
+        @blp.route('/response_wrong_tuple')
+        @blp.response()
+        def func_response_wrong_tuple():
+            return {}, 201, {'X-header': 'test'}, 'extra'
+
+        api.register_blueprint(blp)
+
+        response = client.get('/test/response')
+        assert response.status_code == 200
+        assert response.json == {}
+        response = client.get('/test/response_code_int')
+        assert response.status_code == 201
+        assert response.status == '201 CREATED'
+        assert response.json == {}
+        response = client.get('/test/response_code_str')
+        assert response.status_code == 201
+        assert response.status == '201 CREATED'
+        assert response.json == {}
+        response = client.get('/test/response_headers')
+        assert response.status_code == 200
+        assert response.json == {}
+        assert response.headers['X-header'] == 'test'
+        response = client.get('/test/response_code_int_headers')
+        assert response.status_code == 201
+        assert response.status == '201 CREATED'
+        assert response.json == {}
+        assert response.headers['X-header'] == 'test'
+        response = client.get('/test/response_code_str_headers')
+        assert response.status_code == 201
+        assert response.status == '201 CREATED'
+        assert response.json == {}
+        assert response.headers['X-header'] == 'test'
+        response = client.get('/test/response_wrong_tuple')
+        assert response.status_code == 500


### PR DESCRIPTION
Closes #18.
Closes #22.

This PR adds support for view functions returning a tuple or a `Response` object in a `Blueprint.response` decorator, and for view functions returning a tuple in a `Blueprint.paginate` decorator.