### PR TITLE
Rename Api.definition as Api.schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Changelog
 Features:
 
 - Official Python 3.7 support (:pr:`45`).
+- Rename ``Api.definition`` as ``Api.schema``. Keep ``Api.definition`` as an
+  alias to ``Api.schema`` for backward compatibility.
 
 0.14.0 (2019-03-08)
 +++++++++++++++++++

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -15,6 +15,7 @@ Api
 .. autoclass:: flask_rest_api.Api
     :members:
 
+    .. automethod:: schema
     .. automethod:: definition
     .. automethod:: register_converter
     .. automethod:: register_field

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -117,17 +117,16 @@ Register Definitions
 --------------------
 
 When a schema is used multiple times throughout the spec, it is better to
-add it to the spec's definitions so as to reference it rather than duplicate
-its content.
+add it to the spec's schema components so as to reference it rather than
+duplicate its content.
 
-To register a definition from a schema, use the :meth:`Api.definition`
-decorator:
+To register a schema, use the :meth:`Api.schema` decorator:
 
 .. code-block:: python
 
     api = Api()
 
-    @api.definition('Pet')
+    @api.schema('Pet')
     class Pet(Schema):
         ...
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -47,7 +47,7 @@ Define a marshmallow :class:`Schema <marshmallow.Schema>` to expose the model.
 
 .. code-block:: python
 
-    @api.definition('Pet')
+    @api.schema('Pet')
     class PetSchema(ma.Schema):
 
         class Meta:

--- a/flask_rest_api/__init__.py
+++ b/flask_rest_api/__init__.py
@@ -41,7 +41,7 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         self._app = app
         self.spec = None
         # Use lists to enforce order
-        self._definitions = []
+        self._schemas = []
         self._fields = []
         self._converters = []
         if app is not None:

--- a/flask_rest_api/blueprint.py
+++ b/flask_rest_api/blueprint.py
@@ -27,7 +27,7 @@ Documentation process works in several steps:
 
 - At initialization time
 
-  - Schema instances are replaced either by their reference in the `definition`
+  - Schema instances are replaced either by their reference in the `schemas`
     section of the spec if applicable, otherwise by their json representation.
 
   - Automatic documentation is adapted to OpenAPI version and deep-merged with
@@ -146,10 +146,10 @@ class Blueprint(
         """Register views information in documentation
 
         If a schema in a parameter or a response appears in the spec
-        `definitions` section, it is replaced by a reference to its definition
-        in the parameter or response documentation:
+        `schemas` section, it is replaced by a reference in the parameter or
+        response documentation:
 
-        "schema":{"$ref": "#/definitions/MySchema"}
+        "schema":{"$ref": "#/components/schemas/MySchema"}
         """
         # This method uses the documentation information associated with each
         # endpoint in self._[auto|manual]_docs to provide documentation for

--- a/flask_rest_api/spec/__init__.py
+++ b/flask_rest_api/spec/__init__.py
@@ -188,7 +188,7 @@ class APISpecMixin(DocBlueprintMixin):
         # Register custom fields in spec
         for args in self._fields:
             self._register_field(*args)
-        # Register schema definitions in spec
+        # Register schemas in spec
         for name, schema_cls, kwargs in self._schemas:
             self.spec.components.schema(name, schema=schema_cls, **kwargs)
         # Register custom converters in spec
@@ -216,8 +216,10 @@ class APISpecMixin(DocBlueprintMixin):
                 self.spec.components.schema(name, schema=schema_cls, **kwargs)
             return schema_cls
         return decorator
-    # Compatibility
-    definition = schema
+
+    def definition(self, name):
+        """Alias to :meth:`schema <Api.schema>`"""
+        return self.schema(name)
 
     def register_converter(self, converter, conv_type, conv_format=None):
         """Register custom path parameter converter
@@ -278,8 +280,8 @@ class APISpecMixin(DocBlueprintMixin):
             # Map to ('integer, 'int32') passing a code marshmallow field
             api.register_field(CustomInteger, ma.fields.Integer)
 
-        Should be called before registering definitions with
-        :meth:`definition <Api.definition>`.
+        Should be called before registering schemas with
+        :meth:`schema <Api.schema>`.
         """
         self._fields.append((field, *args))
         # Register field in spec if app is already initialized

--- a/flask_rest_api/spec/__init__.py
+++ b/flask_rest_api/spec/__init__.py
@@ -189,33 +189,35 @@ class APISpecMixin(DocBlueprintMixin):
         for args in self._fields:
             self._register_field(*args)
         # Register schema definitions in spec
-        for name, schema_cls, kwargs in self._definitions:
+        for name, schema_cls, kwargs in self._schemas:
             self.spec.components.schema(name, schema=schema_cls, **kwargs)
         # Register custom converters in spec
         for args in self._converters:
             self._register_converter(*args)
 
-    def definition(self, name):
+    def schema(self, name):
         """Decorator to register a Schema in the doc
 
-        This allows a schema to be defined once in the `definitions`
+        This allows a schema to be defined once in the `schemas`
         section of the spec and be referenced throughout the spec.
 
-        :param str name: Name of the definition in the spec
+        :param str name: Name of the schema in the spec
 
             Example: ::
 
-                @api.definition('Pet')
+                @api.schema('Pet')
                 class PetSchema(Schema):
                     ...
         """
         def decorator(schema_cls, **kwargs):
-            self._definitions.append((name, schema_cls, kwargs))
-            # Register definition in spec if app is already initialized
+            self._schemas.append((name, schema_cls, kwargs))
+            # Register schema in spec if app is already initialized
             if self.spec is not None:
                 self.spec.components.schema(name, schema=schema_cls, **kwargs)
             return schema_cls
         return decorator
+    # Compatibility
+    definition = schema
 
     def register_converter(self, converter, conv_type, conv_format=None):
         """Register custom path parameter converter

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,16 @@ from .utils import get_schemas
 class TestApi():
     """Test Api class"""
 
+    def test_api_schema(self, app, schemas):
+        DocSchema = schemas.DocSchema
+        api = Api(app)
+        with mock.patch.object(apispec.core.Components, 'schema') as mock_def:
+            ret = api.schema('Document')(DocSchema)
+        assert ret is DocSchema
+        mock_def.assert_called_once_with('Document', schema=DocSchema)
+
     def test_api_definition(self, app, schemas):
+        """Compatibility: definition is an alias for schema"""
         DocSchema = schemas.DocSchema
         api = Api(app)
         with mock.patch.object(apispec.core.Components, 'schema') as mock_def:
@@ -28,22 +37,22 @@ class TestApi():
         mock_def.assert_called_once_with('Document', schema=DocSchema)
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
-    def test_api_definition_before_and_after_init(self, app, openapi_version):
+    def test_api_schema_before_and_after_init(self, app, openapi_version):
         app.config['OPENAPI_VERSION'] = openapi_version
         api = Api()
 
-        @api.definition('Schema_1')
+        @api.schema('Schema_1')
         class Schema_1(ma.Schema):
             int_1 = ma.fields.Int()
 
         api.init_app(app)
 
-        @api.definition('Schema_2')
+        @api.schema('Schema_2')
         class Schema_2(ma.Schema):
             int_2 = ma.fields.Int()
 
-        definitions = get_schemas(api.spec)
-        assert {'Schema_1', 'Schema_2'}.issubset(definitions)
+        schema_defs = get_schemas(api.spec)
+        assert {'Schema_1', 'Schema_2'}.issubset(schema_defs)
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
     @pytest.mark.parametrize('view_type', ['function', 'method'])
@@ -133,7 +142,7 @@ class TestApi():
 
         api.register_field(CustomField, *mapping)
 
-        @api.definition('Document')
+        @api.schema('Document')
         class Document(ma.Schema):
             field = CustomField()
 
@@ -162,7 +171,7 @@ class TestApi():
 
         api.register_field(CustomField_1, 'custom string', 'custom')
 
-        @api.definition('Schema_1')
+        @api.schema('Schema_1')
         class Schema_1(ma.Schema):
             int_1 = ma.fields.Int()
             custom_1 = CustomField_1()
@@ -170,15 +179,15 @@ class TestApi():
         api.init_app(app)
         api.register_field(CustomField_2, 'custom string', 'custom')
 
-        @api.definition('Schema_2')
+        @api.schema('Schema_2')
         class Schema_2(ma.Schema):
             int_2 = ma.fields.Int()
             custom_2 = CustomField_2()
 
-        definitions = get_schemas(api.spec)
-        assert definitions['Schema_1']['properties']['custom_1'] == {
+        schema_defs = get_schemas(api.spec)
+        assert schema_defs['Schema_1']['properties']['custom_1'] == {
             'type': 'custom string', 'format': 'custom'}
-        assert definitions['Schema_2']['properties']['custom_2'] == {
+        assert schema_defs['Schema_2']['properties']['custom_2'] == {
             'type': 'custom string', 'format': 'custom'}
 
     def test_api_extra_spec_kwargs(self, app):
@@ -200,7 +209,7 @@ class TestApi():
                 return {'dummy': 'whatever'}
 
         api = Api(app, spec_kwargs={'extra_plugins': (MyPlugin(), )})
-        api.definition('Pet')(schemas.DocSchema)
+        api.schema('Pet')(schemas.DocSchema)
         assert get_schemas(api.spec)['Pet']['dummy'] == 'whatever'
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ import apispec
 from flask_rest_api import Api, Blueprint
 from flask_rest_api.exceptions import OpenAPIVersionNotSpecified
 
-from .utils import get_definitions
+from .utils import get_schemas
 
 
 class TestApi():
@@ -42,7 +42,7 @@ class TestApi():
         class Schema_2(ma.Schema):
             int_2 = ma.fields.Int()
 
-        definitions = get_definitions(api.spec)
+        definitions = get_schemas(api.spec)
         assert {'Schema_1', 'Schema_2'}.issubset(definitions)
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
@@ -145,7 +145,7 @@ class TestApi():
         else:
             properties = {'field': {'type': 'integer', 'format': 'int32'}}
 
-        assert get_definitions(api.spec)['Document'] == {
+        assert get_schemas(api.spec)['Document'] == {
             'properties': properties, 'type': 'object'}
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
@@ -175,7 +175,7 @@ class TestApi():
             int_2 = ma.fields.Int()
             custom_2 = CustomField_2()
 
-        definitions = get_definitions(api.spec)
+        definitions = get_schemas(api.spec)
         assert definitions['Schema_1']['properties']['custom_1'] == {
             'type': 'custom string', 'format': 'custom'}
         assert definitions['Schema_2']['properties']['custom_2'] == {
@@ -201,7 +201,7 @@ class TestApi():
 
         api = Api(app, spec_kwargs={'extra_plugins': (MyPlugin(), )})
         api.definition('Pet')(schemas.DocSchema)
-        assert get_definitions(api.spec)['Pet']['dummy'] == 'whatever'
+        assert get_schemas(api.spec)['Pet']['dummy'] == 'whatever'
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
     def test_api_gets_apispec_parameters_from_app(self, app, openapi_version):

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -204,7 +204,7 @@ class TestBlueprint():
         api = Api(app)
         blp = Blueprint('test', 'test', url_prefix='/test')
 
-        api.definition('Doc')(schemas.DocSchema)
+        api.schema('Doc')(schemas.DocSchema)
 
         @blp.route('/schema_many_false')
         @blp.response(schemas.DocSchema(many=False))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,8 +39,8 @@ class NoLoggingContext:
         self.app.logger.disabled = self.logger_was_disabled
 
 
-def get_definitions(spec):
+def get_schemas(spec):
     """Get definitions/schemas from spec"""
     if spec.openapi_version.major < 3:
-        return spec.to_dict()['definitions']
-    return spec.to_dict()['components']['schemas']
+        return spec.to_dict().get('definitions')
+    return spec.to_dict()['components'].get('schemas')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,7 +40,7 @@ class NoLoggingContext:
 
 
 def get_schemas(spec):
-    """Get definitions/schemas from spec"""
+    """Get schema components from spec"""
     if spec.openapi_version.major < 3:
         return spec.to_dict().get('definitions')
     return spec.to_dict()['components'].get('schemas')


### PR DESCRIPTION
Let's stick to OAS3 terminology, like apispec does.