### PR TITLE
Support `defaults` in `route`

### DIFF
--- a/flask_rest_api/spec/plugins.py
+++ b/flask_rest_api/spec/plugins.py
@@ -59,6 +59,8 @@ class FlaskPlugin(BasePlugin):
         """Get parameters from flask Rule"""
         params = []
         for argument in rule.arguments:
+            if argument in rule.defaults:
+                continue
             param = {
                 'in': 'path',
                 'name': argument,


### PR DESCRIPTION
Small fix that allows the use of `defaults` in a route:
```
@ns.route('/<int:pet_id>/<int:version>', methods=['GET'])
@ns.route('/<int:pet_id>/', defaults={'version': None}, methods=['GET'])
class Pet(MethodView):
```