### PR TITLE
Enable setting swagger defaultModelsExpandDepth value

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors (chronological)
 - Douglas Thor `@dougthor42 <https://github.com/dougthor42>`_
 - Steven Loria `@sloria <https://github.com/sloria>`_
 - Jón Bjarnason `@nonnib <https://github.com/nonnib>`_
+- Geoffrey Hausheer `@PhracturedBlue <https://github.com/PhracturedBlue>`_

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -313,6 +313,15 @@ Here's an example application configuration using both ReDoc and Swagger UI:
        OPENAPI_SWAGGER_UI_PATH = "/swagger-ui"
        OPENAPI_SWAGGER_UI_URL = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
 
+.. describe:: OPENAPI_SWAGGER_UI_DEFAULT_MODELS_EXPAND_DEPTH
+
+   control the display of the models section on swagger-ui >= 3.7.0.  Supported values:
+      * `1`: Show expanded Models section
+      * `0`: Show collapsed Models section
+      * `-1`: Disable Models section entirely
+
+   Default: `-1`
+
 .. _ReDoc: https://github.com/Rebilly/ReDoc
 .. _Swagger UI: https://swagger.io/tools/swagger-ui/
 

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -87,6 +87,10 @@ class DocBlueprintMixin:
                         ['get', 'put', 'post', 'delete', 'options',
                          'head', 'patch', 'trace'])
                 )
+                self._swagger_ui_default_models_expand_depth = (
+                    self._app.config.get(
+                        'OPENAPI_SWAGGER_UI_DEFAULT_MODELS_EXPAND_DEPTH', 1)
+                )
                 blueprint.add_url_rule(
                     _add_leading_slash(swagger_ui_path),
                     endpoint='openapi_swagger_ui',
@@ -110,6 +114,8 @@ class DocBlueprintMixin:
         return flask.render_template(
             'swagger_ui.html', title=self._app.name,
             swagger_ui_url=self._swagger_ui_url,
+            swagger_ui_default_models_expand_depth=(
+                self._swagger_ui_default_models_expand_depth),
             swagger_ui_supported_submit_methods=(
                 self._swagger_ui_supported_submit_methods)
         )

--- a/flask_smorest/spec/templates/swagger_ui.html
+++ b/flask_smorest/spec/templates/swagger_ui.html
@@ -20,6 +20,7 @@
          deepLinking: true,
          layout: "BaseLayout",
          supportedSubmitMethods: [{% for meth in swagger_ui_supported_submit_methods %}"{{meth.lower()}}",{% endfor %}],
+         defaultModelsExpandDepth: {{swagger_ui_default_models_expand_depth}},
        })
        window.ui = ui
      }


### PR DESCRIPTION
OpenAPI 3.0 by default displays the 'Models' section.  This is configurable via the 'defaultModelsExpandDepth' settings.

This patch provides the ability to set this value via the OPENAPI_SWAGGER_UI_DEFAULT_MODELS_EXPAND_DEPTH config

setting OPENAPI_SWAGGER_UI_DEFAULT_MODELS_EXPAND_DEPTH = -1 will disable the 'Models' section entirely

setting OPENAPI_SWAGGER_UI_DEFAULT_MODELS_EXPAND_DEPTH = 0 will collapse the 'Models' section but still display it

setting OPENAPI_SWAGGER_UI_DEFAULT_MODELS_EXPAND_DEPTH = 1 is the default and will display the models section uncollapsed

