### PR TITLE
Add exemple and examples parameters to @arguments

### DIFF
--- a/flask_rest_api/arguments.py
+++ b/flask_rest_api/arguments.py
@@ -13,7 +13,10 @@ class ArgumentsMixin:
 
     ARGUMENTS_PARSER = FlaskParser()
 
-    def arguments(self, schema, *, location='json', required=True, **kwargs):
+    def arguments(
+            self, schema, *, location='json', required=True,
+            example=None, examples=None, **kwargs
+    ):
         """Decorator specifying the schema used to deserialize parameters
 
         :param type|Schema schema: Marshmallow ``Schema`` class or instance
@@ -24,9 +27,14 @@ class ArgumentsMixin:
             expose the whole schema as a `required` parameter.
             For other locations, the schema is turned into an array of
             parameters and their required value is inferred from the schema.
+        :param dict example: Parameter example.
+        :param list examples: List of parameter examples.
         :param dict kwargs: Keyword arguments passed to the webargs
             :meth:`use_args <webargs.core.Parser.use_args>` decorator used
             internally.
+
+        The `example` and `examples` parameters are mutually exclusive and
+        should only be used with OpenAPI 3 and when location is `json`.
 
         See :doc:`Arguments <arguments>`.
         """
@@ -43,6 +51,10 @@ class ArgumentsMixin:
             'required': required,
             'schema': schema,
         }
+        if example is not None:
+            parameters['example'] = example
+        if examples is not None:
+            parameters['examples'] = examples
 
         def decorator(func):
             # Add parameter to parameters list in doc info in function object

--- a/flask_rest_api/blueprint.py
+++ b/flask_rest_api/blueprint.py
@@ -195,26 +195,27 @@ class Blueprint(
                 for resp in operation['responses'].values():
                     for field in ('schema', 'example', 'examples'):
                         if field in resp:
-                            resp.setdefault('content', {})
-                            resp['content'].setdefault('application/json', {})[
-                                field] = resp.pop(field)
+                            (
+                                resp
+                                .setdefault('content', {})
+                                .setdefault('application/json', {})
+                                [field]
+                            ) = resp.pop(field)
             if 'parameters' in operation:
                 for param in operation['parameters']:
                     if param['in'] == 'body':
                         request_body = {
-                            **{
-                                'content': {
-                                    'application/json': {
-                                        'schema': param['schema']
-                                    }
-                                }
-                            },
-                            **{
-                                x: param[x]
-                                for x in ('description', 'required')
-                                if x in param
-                            }
+                            x: param[x] for x in ('description', 'required')
+                            if x in param
                         }
+                        for field in ('schema', 'example', 'examples'):
+                            if field in param:
+                                (
+                                    request_body
+                                    .setdefault('content', {})
+                                    .setdefault('application/json', {})
+                                    [field]
+                                ) = param.pop(field)
                         operation['requestBody'] = request_body
                         # There can be only one requestBody
                         continue


### PR DESCRIPTION
Closes #66.

Only concerns OAS3 requestBody:
- OAS2 doesn't provide example feature.
- When not in requestBody, each field is a parameter of its own, and the example should be passed in the field itself.