### PR TITLE
Custom docstring ignore tag

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Contributors (chronological)
 ============================
 
 - Ryan Yin `@ryan4yin <https://github.com/ryan4yin>`_
+- Douglas Thor `@dougthor42 <https://github.com/dougthor42>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Features:
   reasonable default content type for ``form`` and ``files`` (:pr:`83`).
 - Add ``description`` parameter to ``Blueprint.arguments`` to pass description
   for ``requestBody`` (:pr:`93`).
+- Allow customization of docstring delimiter string (:issue:`49`).
 
 Bug fixes:
 

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -67,6 +67,63 @@ The example above produces the following documentation attributes:
         }
     }
 
+The separator ``'---'`` can be customized by setting ``docstring_sep``
+when initializing the blueprint, or by subclassing ``Blueprint``:
+
+.. code-block:: python
+
+    blp = Blueprint('foo', __name__, docstring_sep='~~~')
+
+    def get(...):
+        """Find pets by ID
+
+        Return pets based on ID.
+        ~~~
+        Internal comment not meant to be exposed.
+        """
+
+    # This does the same thing:
+    class MyBlueprint('foo', __name__):
+        DOCSTRING_SEP = "~~~"
+
+Produces:
+
+.. code-block:: python
+
+    {
+        'get': {
+            'summary': 'Find pets by ID',
+            'description': 'Return pets based on ID',
+        }
+    }
+
+Setting ``docstring_sep`` to ``None`` will result in the entire docstring
+being included in the `description`:
+
+.. code-block:: python
+
+    blp = Blueprint('foo', __name__, docstring_sep=None)
+
+    def get(...):
+        """Find pets by ID
+
+        Return pets based on ID.
+        ---
+        Even this is included.
+        """
+
+Produces:
+
+.. code-block:: python
+
+    {
+        'get': {
+            'summary': 'Find pets by ID',
+            'description': ('Return pets based on ID\n---\n'
+                            'Even this is included.'),
+        }
+    }
+
 Document Operations Parameters and Responses
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -67,62 +67,10 @@ The example above produces the following documentation attributes:
         }
     }
 
-The separator ``'---'`` can be customized by setting ``docstring_sep``
-when initializing the blueprint, or by subclassing ``Blueprint``:
-
-.. code-block:: python
-
-    blp = Blueprint('foo', __name__, docstring_sep='~~~')
-
-    def get(...):
-        """Find pets by ID
-
-        Return pets based on ID.
-        ~~~
-        Internal comment not meant to be exposed.
-        """
-
-    # This does the same thing:
-    class MyBlueprint('foo', __name__):
-        DOCSTRING_SEP = "~~~"
-
-Produces:
-
-.. code-block:: python
-
-    {
-        'get': {
-            'summary': 'Find pets by ID',
-            'description': 'Return pets based on ID',
-        }
-    }
-
-Setting ``docstring_sep`` to ``None`` will result in the entire docstring
-being included in the `description`:
-
-.. code-block:: python
-
-    blp = Blueprint('foo', __name__, docstring_sep=None)
-
-    def get(...):
-        """Find pets by ID
-
-        Return pets based on ID.
-        ---
-        Even this is included.
-        """
-
-Produces:
-
-.. code-block:: python
-
-    {
-        'get': {
-            'summary': 'Find pets by ID',
-            'description': ('Return pets based on ID\n---\n'
-                            'Even this is included.'),
-        }
-    }
+The delimiter line is the line starting with the delimiter string defined in
+``Blueprint.DOCSTRING_INFO_DELIMITER``. This string defaults to ``"---"`` and
+can be customized in a subclass. ``None`` means "no delimiter": the whole
+docstring is included in the docs.
 
 Document Operations Parameters and Responses
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/flask_rest_api/utils.py
+++ b/flask_rest_api/utils.py
@@ -32,19 +32,22 @@ def get_appcontext():
     return ctx.flask_rest_api
 
 
-def load_info_from_docstring(docstring):
+def load_info_from_docstring(docstring, sep="---"):
     """Load summary and description from docstring"""
     split_lines = trim_docstring(docstring).split('\n')
 
-    # Info is separated from rest of docstring by a '---' line
-    for index, line in enumerate(split_lines):
-        if line.lstrip().startswith('---'):
-            cut_at = index
-            break
-    else:
-        cut_at = index + 1
+    split_info_lines = split_lines
 
-    split_info_lines = split_lines[:cut_at]
+    if sep is not None:
+        # Info is separated from rest of docstring by a `sep` line
+        for index, line in enumerate(split_lines):
+            if line.lstrip().startswith(sep):
+                cut_at = index
+                break
+        else:
+            cut_at = index + 1
+
+        split_info_lines = split_lines[:cut_at]
 
     # Description is separated from summary by an empty line
     for index, line in enumerate(split_info_lines):

--- a/flask_rest_api/utils.py
+++ b/flask_rest_api/utils.py
@@ -32,31 +32,33 @@ def get_appcontext():
     return ctx.flask_rest_api
 
 
-def load_info_from_docstring(docstring, sep="---"):
-    """Load summary and description from docstring"""
+def load_info_from_docstring(docstring, *, delimiter="---"):
+    """Load summary and description from docstring
+
+    :param str delimiter: Summary and description information delimiter.
+    If a line starts with this string, this line and the lines after are
+    ignored. Defaults to "---".
+    """
     split_lines = trim_docstring(docstring).split('\n')
 
-    split_info_lines = split_lines
-
-    if sep is not None:
-        # Info is separated from rest of docstring by a `sep` line
+    if delimiter is not None:
+        # Info is separated from rest of docstring by a `delimiter` line
         for index, line in enumerate(split_lines):
-            if line.lstrip().startswith(sep):
+            if line.lstrip().startswith(delimiter):
                 cut_at = index
                 break
         else:
             cut_at = index + 1
-
-        split_info_lines = split_lines[:cut_at]
+        split_lines = split_lines[:cut_at]
 
     # Description is separated from summary by an empty line
-    for index, line in enumerate(split_info_lines):
+    for index, line in enumerate(split_lines):
         if line.strip() == '':
-            summary_lines = split_info_lines[:index]
-            description_lines = split_info_lines[index + 1:]
+            summary_lines = split_lines[:index]
+            description_lines = split_lines[index + 1:]
             break
     else:
-        summary_lines = split_info_lines
+        summary_lines = split_lines
         description_lines = []
 
     info = {}

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -576,72 +576,6 @@ class TestBlueprint():
         assert response.status_code == 200
         assert response.json == {'Value': 'OK'}
 
-    def test_blueprint_custom_docstring_separator(self, app):
-        api = Api(app)
-        blp = Blueprint('test', __name__, url_prefix='/test',
-                        docstring_sep="~~~")
-
-        @blp.route('/', methods=['PUT'])
-        def view_func():
-            """Summary
-
-            Long description
-            ~~~
-            Ignore
-            """
-            return jsonify({'Value': 'OK'})
-
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
-        path = spec['paths']['/test/']
-        assert path['put']['description'] == 'Long description'
-
-    def test_blueprint_custom_docstring_separator_none(self, app):
-        api = Api(app)
-        blp = Blueprint('test', __name__, url_prefix='/test',
-                        docstring_sep=None)
-
-        @blp.route('/', methods=['PUT'])
-        def view_func():
-            """Summary
-
-            Long description
-            ~~~
-            Not Ignored
-            """
-            return jsonify({'Value': 'OK'})
-
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
-        path = spec['paths']['/test/']
-        descr = path['put']['description']
-        assert descr == 'Long description\n~~~\nNot Ignored'
-
-
-    def test_bluprint_custom_docstring_separator_subclassed(self, app):
-
-        class MyBlueprint(Blueprint):
-            DOCSTRING_SEP = "~~~"
-
-        api = Api(app)
-        blp = MyBlueprint('test', __name__, url_prefix='/test')
-
-        @blp.route('/', methods=['PUT'])
-        def view_func():
-            """Summary
-
-            Long description
-            ~~~
-            Ignore
-            """
-            return jsonify({'Value': 'OK'})
-
-        api.register_blueprint(blp)
-        spec = api.spec.to_dict()
-        path = spec['paths']['/test/']
-        assert path['put']['description'] == 'Long description'
-
-
     def test_blueprint_doc_method_view(self, app):
         api = Api(app)
         blp = Blueprint('test', __name__, url_prefix='/test')
@@ -742,43 +676,50 @@ class TestBlueprint():
         assert resp['description'] == 'Description'
         assert 'schema' in resp['content']['application/json']
 
-    def test_blueprint_doc_info_from_docstring(self, app):
+    @pytest.mark.parametrize('delimiter', (False, None, "---"))
+    def test_blueprint_doc_info_from_docstring(self, app, delimiter):
         api = Api(app)
-        blp = Blueprint('test', __name__, url_prefix='/test')
+
+        class MyBlueprint(Blueprint):
+            # Check delimiter default value
+            if delimiter is not False:
+                DOCSTRING_INFO_DELIMITER = delimiter
+
+        blp = MyBlueprint('test', __name__, url_prefix='/test')
 
         @blp.route('/')
         class Resource(MethodView):
 
             def get(self):
-                """Docstring get summary"""
+                """Get summary"""
 
             def put(self):
-                """Docstring put summary
+                """Put summary
 
-                Docstring put description
+                Put description
+                ---
+                Private docstring
                 """
 
-            @blp.doc(
-                summary='Decorator patch summary',
-                description='Decorator patch description'
-            )
             def patch(self):
-                """Docstring patch summary
-
-                Docstring patch description
-                """
+                pass
 
         api.register_blueprint(blp)
         spec = api.spec.to_dict()
         path = spec['paths']['/test/']
 
-        assert path['get']['summary'] == 'Docstring get summary'
+        assert path['get']['summary'] == 'Get summary'
         assert 'description' not in path['get']
-        assert path['put']['summary'] == 'Docstring put summary'
-        assert path['put']['description'] == 'Docstring put description'
-        # @doc decorator overrides docstring
-        assert path['patch']['summary'] == 'Decorator patch summary'
-        assert path['patch']['description'] == 'Decorator patch description'
+        assert path['put']['summary'] == 'Put summary'
+        if delimiter is None:
+            assert (
+                path['put']['description'] ==
+                'Put description\n---\nPrivate docstring'
+            )
+        else:
+            assert path['put']['description'] == 'Put description'
+        assert 'summary' not in path['patch']
+        assert 'description' not in path['patch']
 
     @pytest.mark.parametrize('http_methods', (
         ['OPTIONS', 'HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,3 +55,53 @@ class TestUtils():
             'summary': 'Summary\nTwo-line summary is possible.',
             'description': 'Long description\nReally long description'
         }
+
+        # No separator
+        docstring = """Summary
+
+        Long description
+
+        Section
+        -------
+        Also included
+        """
+        assert load_info_from_docstring(docstring, sep=None) == {
+            'summary': 'Summary',
+            'description': ('Long description\n\n'
+                            'Section\n-------\nAlso included'),
+        }
+
+        # Custom separator
+        docstring = """Summary
+
+        Some description.
+
+        Section
+        -------
+        foo
+
+        ~~~
+
+        Ignored.
+        """
+        assert load_info_from_docstring(docstring, sep="~~~") == {
+            'summary': 'Summary',
+            'description': ('Some description.\n\n'
+                            'Section\n-------\n'
+                            'foo'
+                            ),
+        }
+
+        # Explicit Default separator
+        docstring = """Summary
+
+        Some description.
+
+        Section
+        -------
+        Ignored
+        """
+        assert load_info_from_docstring(docstring, sep="---") == {
+            'summary': 'Summary',
+            'description': 'Some description.\n\nSection',
+        }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,6 +32,8 @@ class TestUtils():
         }
 
     def test_load_info_from_docstring(self):
+        assert (load_info_from_docstring(None)) == {}
+        assert (load_info_from_docstring(None, delimiter="---")) == {}
         assert (load_info_from_docstring('')) == {}
 
         docstring = """
@@ -51,57 +53,22 @@ class TestUtils():
         ---
         Ignore this.
         """
-        assert load_info_from_docstring(docstring) == {
-            'summary': 'Summary\nTwo-line summary is possible.',
-            'description': 'Long description\nReally long description'
-        }
-
-        # No separator
-        docstring = """Summary
-
-        Long description
-
-        Section
-        -------
-        Also included
-        """
-        assert load_info_from_docstring(docstring, sep=None) == {
-            'summary': 'Summary',
-            'description': ('Long description\n\n'
-                            'Section\n-------\nAlso included'),
-        }
-
-        # Custom separator
-        docstring = """Summary
-
-        Some description.
-
-        Section
-        -------
-        foo
-
-        ~~~
-
-        Ignored.
-        """
-        assert load_info_from_docstring(docstring, sep="~~~") == {
-            'summary': 'Summary',
-            'description': ('Some description.\n\n'
-                            'Section\n-------\n'
-                            'foo'
-                            ),
-        }
-
-        # Explicit Default separator
-        docstring = """Summary
-
-        Some description.
-
-        Section
-        -------
-        Ignored
-        """
-        assert load_info_from_docstring(docstring, sep="---") == {
-            'summary': 'Summary',
-            'description': 'Some description.\n\nSection',
-        }
+        assert (
+            load_info_from_docstring(docstring) ==
+            load_info_from_docstring(docstring, delimiter="---") ==
+            {
+                'summary': 'Summary\nTwo-line summary is possible.',
+                'description': 'Long description\nReally long description',
+            }
+        )
+        assert (
+            load_info_from_docstring(docstring, delimiter=None) ==
+            load_info_from_docstring(docstring, delimiter="~~~") ==
+            {
+                'summary': 'Summary\nTwo-line summary is possible.',
+                'description': (
+                    'Long description\nReally long description\n---\n'
+                    'Ignore this.'
+                )
+            }
+        )


### PR DESCRIPTION
This allows the user to customize the docstring ignore separator.

The custom separator is set during blueprint initialization:

```python
blp = Blueprint('foo', __name__, docstring_sep="~~~")
@blp.route('/', methods=['GET'])
def view_func():
    """Summary
    
    Descr
    ~~~
    This line and more ignored.
    """
    return "foo"

## Results in:
# summary: "Summary"
# description: "Descr"
```

```python
blp = Blueprint('foo', __name__, docstring_sep=None)
@blp.route('/', methods=['GET'])
def view_func():
    """Summary
    
    Descr
    ~~~
    This line is included.
    """
    return "foo"

## Results in:
# summary: "Summary"
# description: "Descr\n~~~\nThis line is included."
```

Fixes #49.