### PR TITLE
Remove api.schema decorator

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -110,23 +110,6 @@ Note that ``app.config`` overrides ``spec_kwargs``. The example above produces
    flask parameter `APPLICATION_ROOT`. In OpenAPI v3, `basePath` is removed,
    and the `servers` attribute can only be set by the user.
 
-Register Schemas
-----------------
-
-When a schema is used multiple times throughout the spec, it is better to
-add it to the spec's schema components so as to reference it rather than
-duplicate its content.
-
-To register a schema, use the :meth:`Api.schema` decorator:
-
-.. code-block:: python
-
-    api = Api()
-
-    @api.schema('Pet')
-    class Pet(Schema):
-        ...
-
 Register Custom Fields
 ----------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -47,7 +47,6 @@ Define a marshmallow :class:`Schema <marshmallow.Schema>` to expose the model.
 
 .. code-block:: python
 
-    @api.schema('Pet')
     class PetSchema(ma.Schema):
 
         class Meta:

--- a/flask_rest_api/__init__.py
+++ b/flask_rest_api/__init__.py
@@ -41,7 +41,6 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         self._app = app
         self.spec = None
         # Use lists to enforce order
-        self._schemas = []
         self._fields = []
         self._converters = []
         if app is not None:

--- a/flask_rest_api/spec/__init__.py
+++ b/flask_rest_api/spec/__init__.py
@@ -188,38 +188,9 @@ class APISpecMixin(DocBlueprintMixin):
         # Register custom fields in spec
         for args in self._fields:
             self._register_field(*args)
-        # Register schemas in spec
-        for name, schema_cls, kwargs in self._schemas:
-            self.spec.components.schema(name, schema=schema_cls, **kwargs)
         # Register custom converters in spec
         for args in self._converters:
             self._register_converter(*args)
-
-    def schema(self, name):
-        """Decorator to register a Schema in the doc
-
-        This allows a schema to be defined once in the `schemas`
-        section of the spec and be referenced throughout the spec.
-
-        :param str name: Name of the schema in the spec
-
-            Example: ::
-
-                @api.schema('Pet')
-                class PetSchema(Schema):
-                    ...
-        """
-        def decorator(schema_cls, **kwargs):
-            self._schemas.append((name, schema_cls, kwargs))
-            # Register schema in spec if app is already initialized
-            if self.spec is not None:
-                self.spec.components.schema(name, schema=schema_cls, **kwargs)
-            return schema_cls
-        return decorator
-
-    def definition(self, name):
-        """Alias to :meth:`schema <Api.schema>`"""
-        return self.schema(name)
 
     def register_converter(self, converter, conv_type, conv_format=None):
         """Register custom path parameter converter

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -240,8 +240,6 @@ class TestBlueprint():
         api = Api(app)
         blp = Blueprint('test', 'test', url_prefix='/test')
 
-        api.schema('Doc')(schemas.DocSchema)
-
         @blp.route('/schema_many_false')
         @blp.response(schemas.DocSchema(many=False))
         def many_false():


### PR DESCRIPTION
Let's rely on apispec auto-registration.

Rationale in https://github.com/Nobatek/flask-rest-api/issues/38#issuecomment-495527421.