### PR TITLE
Fix error handler for Flask 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'werkzeug>=0.15',
-        'flask>=1.0',
+        'flask>=1.1.0',
         'marshmallow>=2.15.2',
         'webargs>=1.5.2',
         'apispec>=2.0.0',

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -12,23 +12,78 @@ from .utils import NoLoggingContext
 class TestErrorHandler:
 
     @pytest.mark.parametrize('code', default_exceptions)
-    def test_error_handler_registration(self, code, app):
-        """Check custom error handler is registered for all codes"""
+    def test_error_handler_on_abort(self, app, code):
 
         client = app.test_client()
+        logger = app.logger
 
-        @app.route('/')
-        def test():
+        message = 'What a bad request.'
+        errors = {
+            'dimensions': ['Too tall', 'Too wide'],
+            'color': ['Too bright']
+        }
+
+        @app.route('/abort_no_kwargs')
+        def test_abort_no_kwargs():
             abort(code)
+
+        @app.route('/abort_kwargs')
+        def test_abort_kwargs():
+            abort(code, message=message, errors=errors)
 
         Api(app)
 
-        with NoLoggingContext(app):
-            response = client.get('/')
-        assert response.status_code == code
+        # Test error handler logs as INFO with payload content
+        with mock.patch.object(logger, 'info') as mock_info:
+            response = client.get('/abort_no_kwargs')
+            assert mock_info.called
+            args, kwargs = mock_info.call_args
 
+        assert args == (str(code), )
+        assert kwargs == {}
+
+        assert response.status_code == code
         data = json.loads(response.get_data(as_text=True))
         assert data['status'] == str(default_exceptions[code]())
+
+        with mock.patch.object(logger, 'info') as mock_info:
+            response = client.get('/abort_kwargs')
+            assert mock_info.called
+            args, kwargs = mock_info.call_args
+
+        assert args == (' '.join([str(code), message, str(errors)]), )
+        assert kwargs == {}
+
+    def test_error_handler_on_unhandled_error(self, app):
+
+        client = app.test_client()
+        logger = app.logger
+
+        uncaught_exc = Exception('Oops, something really bad happened.')
+
+        @app.route('/uncaught')
+        def test_uncaught():
+            raise uncaught_exc
+
+        Api(app)
+
+        # Test Flask logs uncaught exception as ERROR
+        # and handle_http_exception does not log is as INFO
+        with mock.patch.object(logger, 'error') as mock_error:
+            with mock.patch.object(logger, 'info') as mock_info:
+                response = client.get('/uncaught')
+                assert mock_error.called
+                args, kwargs = mock_error.call_args
+                assert not mock_info.called
+
+        assert args == ('Exception on /uncaught [GET]', )
+        exc_info = kwargs['exc_info']
+        _, exc_value, _ = exc_info
+        assert exc_value == uncaught_exc
+
+        assert response.status_code == 500
+        data = json.loads(response.get_data(as_text=True))
+        assert data['status'] == str(InternalServerError())
 
     def test_error_handler_payload(self, app):
 
@@ -84,71 +139,3 @@ class TestErrorHandler:
             response.headers['WWW-Authenticate'] == 'Basic realm="My Server"')
         data = json.loads(response.get_data(as_text=True))
         assert data['message'] == 'Access denied'
-
-    def test_error_handler_uncaught_exception(self, app):
-        """Test uncaught exceptions result in 500 status code being returned"""
-
-        client = app.test_client()
-
-        @app.route('/')
-        def test():
-            raise Exception('Oops, something really bad happened.')
-
-        Api(app)
-
-        with NoLoggingContext(app):
-            response = client.get('/')
-        assert response.status_code == 500
-
-        data = json.loads(response.get_data(as_text=True))
-        assert data['status'] == str(InternalServerError())
-
-    def test_error_handler_logging(self, app):
-
-        client = app.test_client()
-        logger = app.logger
-
-        uncaught_exc = Exception('Oops, something really bad happened.')
-        message = 'What a bad request.'
-        errors = {
-            'dimensions': ['Too tall', 'Too wide'],
-            'color': ['Too bright']
-        }
-
-        @app.route('/uncaught')
-        def test_uncaught():
-            raise uncaught_exc
-
-        @app.route('/abort_no_kwargs')
-        def test_abort_no_kwargs():
-            abort(400)
-
-        @app.route('/abort_kwargs')
-        def test_abort_kwargs():
-            abort(400, message=message, errors=errors)
-
-        Api(app)
-
-        # Test Flask logs uncaught exception
-        with mock.patch.object(logger, 'error') as mock_error:
-            client.get('/uncaught')
-            assert mock_error.called
-            args, kwargs = mock_error.call_args
-            assert args == ('Exception on /uncaught [GET]', )
-            exc_info = kwargs['exc_info']
-            _, exc_value, _ = exc_info
-            assert exc_value == uncaught_exc
-
-        # Test error handler logs as INFO with payload content
-        with mock.patch.object(logger, 'info') as mock_info:
-            client.get('/abort_no_kwargs')
-            assert mock_info.called
-            args, kwargs = mock_info.call_args
-            assert kwargs == {}
-            assert args == ('400', )
-        with mock.patch.object(logger, 'info') as mock_info:
-            client.get('/abort_kwargs')
-            assert mock_info.called
-            args, kwargs = mock_info.call_args
-            assert kwargs == {}
-            assert args == (' '.join(['400', message, str(errors)]), )


### PR DESCRIPTION
https://flask.palletsprojects.com/en/1.1.x/changelog/#version-1-1-0

> Error handlers for InternalServerError or 500 will always be passed an instance of InternalServerError. If they are invoked due to an unhandled exception, that original exception is now available as e.original_exception rather than being passed directly to the handler. The same is true if the handler is for the base HTTPException. This makes error handler behavior more consistent.