### PR TITLE
Error handler: only return status code and short name

### DIFF
--- a/flask_rest_api/error_handler.py
+++ b/flask_rest_api/error_handler.py
@@ -59,7 +59,7 @@ class ErrorHandlerMixin:
     def _prepare_error_response_content(error):
         """Build payload and headers from error"""
         headers = {}
-        payload = {'status': str(error), }
+        payload = {'code': error.code, 'status': error.name}
 
         # Get additional info passed as kwargs when calling abort
         # data may not exist if

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -44,7 +44,8 @@ class TestErrorHandler:
 
         assert response.status_code == code
         data = json.loads(response.get_data(as_text=True))
-        assert data['status'] == str(default_exceptions[code]())
+        assert data['code'] == code
+        assert data['status'] == default_exceptions[code]().name
 
         with mock.patch.object(logger, 'info') as mock_info:
             response = client.get('/abort_kwargs')
@@ -83,7 +84,8 @@ class TestErrorHandler:
 
         assert response.status_code == 500
         data = json.loads(response.get_data(as_text=True))
-        assert data['status'] == str(InternalServerError())
+        assert data['code'] == 500
+        assert data['status'] == InternalServerError().name
 
     def test_error_handler_payload(self, app):
 


### PR DESCRIPTION
Long description is not that useful.

This PR modifies the error handler to only return status code and short name.

We might be better off not returning code and name at all, as the status code of the response speaks for itself, but oh well...