### PR TITLE
Remove JSONResponse

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from flask import Flask
 from flask_smorest.compat import MARSHMALLOW_VERSION_MAJOR
 
 from .mocks import DatabaseMock
-from .utils import JSONResponse
 
 
 class AppConfig:
@@ -31,7 +30,6 @@ def collection(request):
 @pytest.fixture(params=[AppConfig])
 def app(request):
     _app = Flask('API Test')
-    _app.response_class = JSONResponse
     _app.config.from_object(request.param)
     return _app
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,26 +1,4 @@
-from collections import OrderedDict
-import json
-
-from werkzeug.utils import cached_property
-from flask import Response
 from apispec.utils import build_reference
-
-
-class JSONResponse(Response):
-    """
-    A Response class with extra useful helpers, i.e. ``.json`` property.
-
-    Taken from https://github.com/frol/flask-restplus-server-example/
-    Thanks Vlad Frolov
-    """
-    # pylint: disable=too-many-ancestors
-
-    @cached_property
-    def json(self):
-        return json.loads(
-            self.get_data(as_text=True),
-            object_pairs_hook=OrderedDict
-        )
 
 
 def get_schemas(spec):


### PR DESCRIPTION
This is now useless. An equivalent feature has been added to Werkzeug.

https://werkzeug.palletsprojects.com/en/0.15.x/wrappers/#json