### PR TITLE
Restrict webargs to <6.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.18.5 (unreleased)
++++++++++++++++++++
+
+Other changes:
+
+- Restrict webargs to <6.0.0 in setup.py due to breaking changes introduced in
+  webargs 6 (:issue:`117`).
+
 0.18.4 (2020-01-07)
 +++++++++++++++++++
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'werkzeug>=0.15',
         'flask>=1.1.0',
         'marshmallow>=2.15.2',
-        'webargs>=1.5.2',
+        'webargs>=1.5.2,<6.0.0',
         'apispec>=3.0.0',
     ],
 )


### PR DESCRIPTION
webargs 6.0 introduces changes that break flask-smorest.

See #117.

We'll release a major flask-smorest version when webargs 6 is out.