### PR TITLE
Refactor Blueprint._prepare_doc

### DIFF
--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -81,7 +81,7 @@ class ArgumentsMixin:
 
         return decorator
 
-    def _prepare_arguments_doc(self, doc, doc_info, _app, spec):
+    def _prepare_arguments_doc(self, doc, doc_info, spec, **kwargs):
         # This callback should run first as it overrides existing parameters
         # in doc. Following callbacks should append to parameters list.
         operation = doc_info.get('arguments', {})

--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -79,9 +79,9 @@ class ArgumentsMixin:
 
         return decorator
 
-    def _prepare_arguments_doc(self, operation, openapi_version):
+    def _prepare_arguments_doc(self, operation, _app, spec):
         # OAS 2
-        if openapi_version.major < 3:
+        if spec.openapi_version.major < 3:
             if 'parameters' in operation:
                 for param in operation['parameters']:
                     if param['in'] in (

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -193,7 +193,7 @@ class Blueprint(
             doc = OrderedDict()
             for method_l, endpoint_doc in endpoint_auto_doc.items():
                 for func in self._prepare_doc_cbks:
-                    func(endpoint_doc, spec.openapi_version)
+                    func(endpoint_doc, app, spec)
                 # Tag all operations with Blueprint name
                 endpoint_doc['tags'] = [self.name]
                 # Merge auto_doc and manual_doc into doc

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -15,26 +15,23 @@ Documentation process works in several steps:
   - When a MethodView or a view function is decorated, relevant information
     is automatically added to the object's ``_apidoc`` attribute.
 
-  - The ``Blueprint.doc`` decorator stores additional information in a separate
-    ``_api_manual_doc``. It allows the user to specify documentation
-    information that flask-smorest can not - or does not yet - infer from the
-    code.
+  - The ``Blueprint.doc`` decorator stores additional information in there that
+    flask-smorest can not - or does not yet - infer from the code.
 
   - The ``Blueprint.route`` decorator registers the endpoint in the Blueprint
-    and gathers all information about the endpoint in
-    ``Blueprint._auto_docs[endpoint]`` and
-    ``Blueprint._manual_docs[endpoint]``.
+    and gathers all documentation information about the endpoint in
+    ``Blueprint._docs[endpoint]``.
 
 - At initialization time
 
   - Schema instances are replaced by their reference in the `schemas` section
     of the spec components.
 
-  - Automatic documentation is finalized using the information stored in
-    ``Blueprint._auto_docs``, with adaptations to parameters only known at init
+  - Documentation is finalized using the information stored in
+    ``Blueprint._docs``, with adaptations to parameters only known at init
     time, such as OAS version.
 
-  - Automatic documentation is deep-merged with manual documentation.
+  - Manual documentation is deep-merged with automatic documentation.
 
   - Endpoints documentation is registered in the APISpec object.
 """
@@ -84,12 +81,12 @@ class Blueprint(
         #     },
         #     ...
         # }
-        self._auto_docs = OrderedDict()
-        self._manual_docs = OrderedDict()
+        self._docs = OrderedDict()
         self._endpoints = []
         self._prepare_doc_cbks = [
             self._prepare_arguments_doc,
             self._prepare_response_doc,
+            self._prepare_pagination_doc,
         ]
 
     def route(self, rule, *, parameters=None, **options):
@@ -135,28 +132,17 @@ class Blueprint(
     def _store_endpoint_docs(self, endpoint, obj, parameters, **options):
         """Store view or function doc info"""
 
-        endpoint_auto_doc = self._auto_docs.setdefault(
-            endpoint, OrderedDict())
-        endpoint_manual_doc = self._manual_docs.setdefault(
-            endpoint, OrderedDict())
+        endpoint_doc_info = self._docs.setdefault(endpoint, OrderedDict())
 
         def store_method_docs(method, function):
             """Add auto and manual doc to table for later registration"""
-            # Get auto documentation from decorators
+            # Get documentation from decorators
             # and summary/description from docstring
-            # Get manual documentation from @doc decorator
-            auto_doc = getattr(function, '_apidoc', {})
-            auto_doc.update(
-                load_info_from_docstring(
-                    function.__doc__,
-                    delimiter=self.DOCSTRING_INFO_DELIMITER
-                )
-            )
-            manual_doc = getattr(function, '_api_manual_doc', {})
-            # Store function auto and manual docs for later registration
-            method_l = method.lower()
-            endpoint_auto_doc[method_l] = auto_doc
-            endpoint_manual_doc[method_l] = manual_doc
+            doc = getattr(function, '_apidoc', {})
+            doc['docstring'] = load_info_from_docstring(
+                function.__doc__, delimiter=self.DOCSTRING_INFO_DELIMITER)
+            # Store function doc infos for later processing/registration
+            endpoint_doc_info[method.lower()] = doc
 
         # MethodView (class)
         if isinstance(obj, MethodViewType):
@@ -170,7 +156,8 @@ class Blueprint(
             for method in methods:
                 store_method_docs(method, obj)
 
-        endpoint_auto_doc['parameters'] = parameters
+        # Store parameters doc info from route decorator
+        endpoint_doc_info['parameters'] = parameters
 
     def register_views_in_doc(self, app, spec):
         """Register views information in documentation
@@ -182,23 +169,25 @@ class Blueprint(
         "schema":{"$ref": "#/components/schemas/MySchema"}
         """
         # This method uses the documentation information associated with each
-        # endpoint in self._[auto|manual]_docs to provide documentation for
-        # corresponding route to the spec object.
-        # Deepcopy to avoid mutating the source
-        # Allows registering blueprint multiple times (e.g. when creating
-        # multiple apps during tests)
-        auto_docs = deepcopy(self._auto_docs)
-        for endpoint, endpoint_auto_doc in auto_docs.items():
-            parameters = endpoint_auto_doc.pop('parameters')
+        # endpoint in self._docs to provide documentation for corresponding
+        # route to the spec object.
+        # Deepcopy to avoid mutating the source. Allows registering blueprint
+        # multiple times (e.g. when creating multiple apps during tests).
+        for endpoint, endpoint_doc_info in deepcopy(self._docs).items():
+            parameters = endpoint_doc_info.pop('parameters')
             doc = OrderedDict()
-            for method_l, endpoint_doc in endpoint_auto_doc.items():
+            # Use doc info stored by decorators to generate doc
+            for method_l, operation_doc_info in endpoint_doc_info.items():
+                operation_doc = {}
                 for func in self._prepare_doc_cbks:
-                    func(endpoint_doc, app, spec)
+                    operation_doc = func(
+                        operation_doc, operation_doc_info, app, spec)
+                operation_doc.update(operation_doc_info['docstring'])
                 # Tag all operations with Blueprint name
-                endpoint_doc['tags'] = [self.name]
-                # Merge auto_doc and manual_doc into doc
-                manual_doc = self._manual_docs[endpoint][method_l]
-                doc[method_l] = deepupdate(endpoint_doc, manual_doc)
+                operation_doc['tags'] = [self.name]
+                # Complete doc with manual doc info
+                manual_doc = operation_doc_info.get('manual_doc', {})
+                doc[method_l] = deepupdate(operation_doc, manual_doc)
 
             # Thanks to self.route, there can only be one rule per endpoint
             full_endpoint = '.'.join((self.name, endpoint))
@@ -225,11 +214,10 @@ class Blueprint(
             def wrapper(*f_args, **f_kwargs):
                 return func(*f_args, **f_kwargs)
 
-            # Don't merge manual doc with auto-documentation right now.
-            # Store it in a separate attribute to merge it later.
             # The deepcopy avoids modifying the wrapped function doc
-            wrapper._api_manual_doc = deepupdate(
-                deepcopy(getattr(wrapper, '_api_manual_doc', {})), kwargs)
+            wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
+            wrapper._apidoc['manual_doc'] = deepupdate(
+                deepcopy(wrapper._apidoc.get('manual_doc', {})), kwargs)
             return wrapper
 
         return decorator

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -27,8 +27,8 @@ Documentation process works in several steps:
 
 - At initialization time
 
-  - Schema instances are replaced either by their reference in the `schemas`
-    section of the spec if applicable, otherwise by their json representation.
+  - Schema instances are replaced by their reference in the `schemas` section
+    of the spec components.
 
   - Automatic documentation is adapted to OpenAPI version and deep-merged with
     manual documentation.

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -181,7 +181,12 @@ class Blueprint(
                 operation_doc = {}
                 for func in self._prepare_doc_cbks:
                     operation_doc = func(
-                        operation_doc, operation_doc_info, app, spec)
+                        operation_doc,
+                        operation_doc_info,
+                        app=app,
+                        spec=spec,
+                        method=method_l
+                    )
                 operation_doc.update(operation_doc_info['docstring'])
                 # Tag all operations with Blueprint name
                 operation_doc['tags'] = [self.name]

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -229,7 +229,7 @@ class PaginationMixin:
         return json.dumps(page_header)
 
     @staticmethod
-    def _prepare_pagination_doc(doc, doc_info, _app, _spec):
+    def _prepare_pagination_doc(doc, doc_info, **kwargs):
         operation = doc_info.get('pagination', {})
         parameters = operation.get('parameters')
         if parameters:

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -9,6 +9,7 @@ Two pagination modes are supported:
   a pager is provided to paginate the data and get the total number of items.
 """
 
+from copy import deepcopy
 from collections import OrderedDict
 from functools import wraps
 import json
@@ -156,9 +157,6 @@ class PaginationMixin:
         }
 
         def decorator(func):
-            # Add pagination params to doc info in function object
-            func._apidoc = getattr(func, '_apidoc', {})
-            func._apidoc.setdefault('parameters', []).append(parameters)
 
             @wraps(func)
             def wrapper(*args, **kwargs):
@@ -194,6 +192,10 @@ class PaginationMixin:
 
                 return result, status, headers
 
+            # Add pagination params to doc info in wrapper object
+            wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
+            wrapper._apidoc['pagination'] = {'parameters': parameters}
+
             return wrapper
 
         return decorator
@@ -225,3 +227,11 @@ class PaginationMixin:
                 if page < last_page:
                     page_header['next_page'] = page + 1
         return json.dumps(page_header)
+
+    @staticmethod
+    def _prepare_pagination_doc(doc, doc_info, _app, _spec):
+        operation = doc_info.get('pagination', {})
+        parameters = operation.get('parameters')
+        if parameters:
+            doc.setdefault('parameters', []).append(parameters)
+        return doc

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -145,7 +145,7 @@ class ResponseMixin:
         return data
 
     @staticmethod
-    def _prepare_response_doc(doc, doc_info, _app, spec):
+    def _prepare_response_doc(doc, doc_info, spec, **kwargs):
         operation = doc_info.get('response', {})
         # OAS 2
         if spec.openapi_version.major < 3:

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -114,9 +114,10 @@ class ResponseMixin:
 
         return decorator
 
-    def _prepare_response_doc(self, operation, openapi_version):
+    @staticmethod
+    def _prepare_response_doc(operation, _app, spec):
         # OAS 2
-        if openapi_version.major < 3:
+        if spec.openapi_version.major < 3:
             if 'responses' in operation:
                 for resp in operation['responses'].values():
                     if 'example' in resp:

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -67,7 +67,6 @@ class ResponseMixin:
             resp_doc['examples'] = examples
         if headers is not None:
             resp_doc['headers'] = headers
-        doc = {'responses': {code: resp_doc}}
 
         def decorator(func):
 
@@ -107,34 +106,12 @@ class ResponseMixin:
 
             # Store doc in wrapper function
             # The deepcopy avoids modifying the wrapped function doc
-            wrapper._apidoc = deepupdate(
-                deepcopy(getattr(wrapper, '_apidoc', {})), doc)
+            wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
+            wrapper._apidoc['response'] = {'responses': {code: resp_doc}}
 
             return wrapper
 
         return decorator
-
-    @staticmethod
-    def _prepare_response_doc(operation, _app, spec):
-        # OAS 2
-        if spec.openapi_version.major < 3:
-            if 'responses' in operation:
-                for resp in operation['responses'].values():
-                    if 'example' in resp:
-                        resp['examples'] = {
-                            DEFAULT_RESPONSE_CONTENT_TYPE: resp.pop('example')}
-        # OAS 3
-        else:
-            if 'responses' in operation:
-                for resp in operation['responses'].values():
-                    for field in ('schema', 'example', 'examples'):
-                        if field in resp:
-                            (
-                                resp
-                                .setdefault('content', {})
-                                .setdefault(DEFAULT_RESPONSE_CONTENT_TYPE, {})
-                                [field]
-                            ) = resp.pop(field)
 
     @staticmethod
     def _make_doc_response_schema(schema):
@@ -166,3 +143,28 @@ class ResponseMixin:
                     return {'type': 'success', 'data': schema}
         """
         return data
+
+    @staticmethod
+    def _prepare_response_doc(doc, doc_info, _app, spec):
+        operation = doc_info.get('response', {})
+        # OAS 2
+        if spec.openapi_version.major < 3:
+            if 'responses' in operation:
+                for resp in operation['responses'].values():
+                    if 'example' in resp:
+                        resp['examples'] = {
+                            DEFAULT_RESPONSE_CONTENT_TYPE: resp.pop('example')}
+        # OAS 3
+        else:
+            if 'responses' in operation:
+                for resp in operation['responses'].values():
+                    for field in ('schema', 'example', 'examples'):
+                        if field in resp:
+                            (
+                                resp
+                                .setdefault('content', {})
+                                .setdefault(DEFAULT_RESPONSE_CONTENT_TYPE, {})
+                                [field]
+                            ) = resp.pop(field)
+        doc = deepupdate(doc, operation)
+        return doc

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -579,38 +579,37 @@ class TestBlueprint():
 
         # Check parameters are documented
         parameters = spec['paths']['/test/']['get']['parameters']
-        # Page
-        assert parameters[0]['name'] == 'page'
+        # Query string parameters
+        assert parameters[0]['name'] == 'arg1'
         assert parameters[0]['in'] == 'query'
-        assert parameters[0]['required'] is False
-        if openapi_version == '2.0':
-            assert parameters[0]['type'] == 'integer'
-            assert parameters[0]['default'] == 1
-            assert parameters[0]['minimum'] == 1
-        else:
-            assert parameters[0]['schema']['type'] == 'integer'
-            assert parameters[0]['schema']['default'] == 1
-            assert parameters[0]['schema']['minimum'] == 1
-        # Page size
-        assert parameters[1]['name'] == 'page_size'
+        assert parameters[1]['name'] == 'arg2'
         assert parameters[1]['in'] == 'query'
-        assert parameters[1]['required'] is False
-        if openapi_version == '2.0':
-            assert parameters[1]['type'] == 'integer'
-            assert parameters[1]['default'] == 10
-            assert parameters[1]['minimum'] == 1
-            assert parameters[1]['maximum'] == 100
-        else:
-            assert parameters[1]['schema']['type'] == 'integer'
-            assert parameters[1]['schema']['default'] == 10
-            assert parameters[1]['schema']['minimum'] == 1
-            assert parameters[1]['schema']['maximum'] == 100
-        # Other query string parameters
-        assert parameters[1]['in'] == 'query'
-        assert parameters[2]['name'] == 'arg1'
+        # Page
+        assert parameters[2]['name'] == 'page'
         assert parameters[2]['in'] == 'query'
-        assert parameters[3]['name'] == 'arg2'
+        assert parameters[2]['required'] is False
+        if openapi_version == '2.0':
+            assert parameters[2]['type'] == 'integer'
+            assert parameters[2]['default'] == 1
+            assert parameters[2]['minimum'] == 1
+        else:
+            assert parameters[2]['schema']['type'] == 'integer'
+            assert parameters[2]['schema']['default'] == 1
+            assert parameters[2]['schema']['minimum'] == 1
+        # Page size
+        assert parameters[3]['name'] == 'page_size'
         assert parameters[3]['in'] == 'query'
+        assert parameters[3]['required'] is False
+        if openapi_version == '2.0':
+            assert parameters[3]['type'] == 'integer'
+            assert parameters[3]['default'] == 10
+            assert parameters[3]['minimum'] == 1
+            assert parameters[3]['maximum'] == 100
+        else:
+            assert parameters[3]['schema']['type'] == 'integer'
+            assert parameters[3]['schema']['default'] == 10
+            assert parameters[3]['schema']['minimum'] == 1
+            assert parameters[3]['schema']['maximum'] == 100
 
     def test_blueprint_doc_function(self, app):
         api = Api(app)


### PR DESCRIPTION
The decorators write doc information in each view function `_apispec` attribute. Since the docs may vary according to the OAS version, `Blueprint._prepare_doc` does some modifications at init time when the version is known.

This is far from perfect.

- [x] First, it is a simplification. The decorators write docs in a structure close to OAS then `_prepare_doc` just does a few fixes. It would be more generic if the decorators wrote docs in an independent structure and then the doc would be generated at once when all parameters are known. ~This PR does not address that yet.~

- [x] Each decorator (each Mixin) should be responsible for his documentation. This PR fixes this by splitting the preparation in separate methods.

- [x] The OAS version is not the only parameter that can be discovered at init time. There could also be application parameter affecting docs, such as whether or not a feature (authentication, ETag,...) is active. This PR fixes this by passing app and spec to the preparation methods.

Users willing to extend flask-smorest may create their own `_prepare_x_doc` methods and add them to the list of processors when subclassing `Blueprint`.

We should go a little bit further and decide that each decorator puts its own stuff in a namespaced substructure (e.g. `arguments` in `_apispec["arguments"]`) and the final doc structure is written at init time. For a start, the initial substructure can be the current final-doc-like structure. No need for more abstraction. But there may be cases in other decorators where it makes more sense to store parameters first then write doc than to first write doc then fix it. Without the namespacing, decorators all write temporary doc in the same structure so there could be interference between them.