### PR TITLE
Auto document errors, pagination, ETag

### DIFF
--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -1,5 +1,7 @@
 """Api extension initialization"""
 
+import http
+
 from webargs.flaskparser import abort  # noqa
 
 from .spec import APISpecMixin, DEFAULT_RESPONSE_CONTENT_TYPE
@@ -71,44 +73,33 @@ class Api(APISpecMixin, ErrorHandlerMixin):
 
         # Resister error responses
         self._register_response(
-            'DefaultError',
+            'Default Error',
             {
                 'description': 'Default error response',
                 'schema': self.ERROR_SCHEMA,
             }
         )
+        self._register_default_response(422)
+        if not app.config.get('ETAG_DISABLED', False):
+            self._register_default_response(304)
+            self._register_default_response(412)
+            self._register_default_response(428)
+
+    def _register_default_response(self, code):
+        """Register a Response for a given status code
+
+        :param int code: Status code
+        """
         self._register_response(
-            'UnprocessableEntity',
+            http.HTTPStatus(code).phrase,
             {
-                'description': 'Unprocessable entity',
+                'description': http.HTTPStatus(code).phrase,
                 'schema': self.ERROR_SCHEMA,
             }
         )
-        if not app.config.get('ETAG_DISABLED', False):
-            self._register_response(
-                'NotModified',
-                {
-                    'description': 'Not Modified',
-                    'schema': self.ERROR_SCHEMA,
-                }
-            )
-            self._register_response(
-                'PreconditionFailed',
-                {
-                    'description': 'Precondition Failed',
-                    'schema': self.ERROR_SCHEMA,
-                }
-            )
-            self._register_response(
-                'PreconditionRequired',
-                {
-                    'description': 'Precondition Required',
-                    'schema': self.ERROR_SCHEMA,
-                }
-            )
 
     def _register_response(self, component_id, component):
-        """Register a response component
+        """Register a Response component
 
         Abstracts OpenAPI version and content type.
         """

--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -84,6 +84,21 @@ class Api(APISpecMixin, ErrorHandlerMixin):
                 'schema': self.ERROR_SCHEMA,
             }
         )
+        if not app.config.get('ETAG_DISABLED', False):
+            self._register_response(
+                'PreconditionFailed',
+                {
+                    'description': 'Precondition Failed',
+                    'schema': self.ERROR_SCHEMA,
+                }
+            )
+            self._register_response(
+                'PreconditionRequired',
+                {
+                    'description': 'Precondition Required',
+                    'schema': self.ERROR_SCHEMA,
+                }
+            )
 
     def _register_response(self, component_id, component):
         """Register a response component

--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -86,6 +86,13 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         )
         if not app.config.get('ETAG_DISABLED', False):
             self._register_response(
+                'NotModified',
+                {
+                    'description': 'Not Modified',
+                    'schema': self.ERROR_SCHEMA,
+                }
+            )
+            self._register_response(
                 'PreconditionFailed',
                 {
                     'description': 'Precondition Failed',

--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -1,14 +1,11 @@
 """Api extension initialization"""
 
-import http
-
 from webargs.flaskparser import abort  # noqa
 
-from .spec import APISpecMixin, DEFAULT_RESPONSE_CONTENT_TYPE
+from .spec import APISpecMixin
 from .blueprint import Blueprint  # noqa
 from .pagination import Page  # noqa
 from .error_handler import ErrorHandlerMixin
-from .utils import prepare_response
 
 __version__ = '0.18.5'
 
@@ -72,31 +69,13 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         # Register error handlers
         self._register_error_handlers()
 
-        # Resister error responses
-        default_error_response = {
-            'description': 'Default error response',
-            'schema': self.ERROR_SCHEMA,
-        }
-        prepare_response(
-            default_error_response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
-        self.spec.components.response('Default Error', default_error_response)
-        self._register_default_response(422)
+        # Register responses
+        self._register_default_error_response()
+        self._register_default_response_by_code(422)
         if not app.config.get('ETAG_DISABLED', False):
-            self._register_default_response(304)
-            self._register_default_response(412)
-            self._register_default_response(428)
-
-    def _register_default_response(self, code):
-        """Register a Response for a given status code
-
-        :param int code: Status code
-        """
-        response = {
-            'description': http.HTTPStatus(code).phrase,
-            'schema': self.ERROR_SCHEMA,
-        }
-        prepare_response(response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
-        self.spec.components.response(http.HTTPStatus(code).phrase, response)
+            self._register_default_response_by_code(304)
+            self._register_default_response_by_code(412)
+            self._register_default_response_by_code(428)
 
     def register_blueprint(self, blp, **options):
         """Register a blueprint in the application

--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -70,12 +70,7 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         self._register_error_handlers()
 
         # Register responses
-        self._register_default_error_response()
-        self._register_default_response_by_code(422)
-        if not app.config.get('ETAG_DISABLED', False):
-            self._register_default_response_by_code(304)
-            self._register_default_response_by_code(412)
-            self._register_default_response_by_code(428)
+        self._register_responses()
 
     def register_blueprint(self, blp, **options):
         """Register a blueprint in the application

--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -81,7 +81,7 @@ class ArgumentsMixin:
 
         return decorator
 
-    def _prepare_arguments_doc(self, doc, doc_info, _app, spec):
+    def _prepare_arguments_doc(self, doc, doc_info, spec, **kwargs):
         # This callback should run first as it overrides existing parameters
         # in doc. Following callbacks should append to parameters list.
         operation = doc_info.get('arguments', {})

--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -3,6 +3,7 @@
 from collections import abc
 from copy import deepcopy
 from functools import wraps
+import http
 
 from webargs.flaskparser import FlaskParser
 
@@ -83,7 +84,7 @@ class ArgumentsMixin:
             docs.setdefault('parameters', []).append(parameters)
             docs.setdefault('responses', {})[
                 error_status_code
-            ] = 'UnprocessableEntity'
+            ] = http.HTTPStatus(error_status_code).phrase
 
             # Call use_args (from webargs) to inject params in function
             return self.ARGUMENTS_PARSER.use_args(

--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -79,9 +79,9 @@ class ArgumentsMixin:
 
         return decorator
 
-    def _prepare_arguments_doc(self, operation, openapi_version):
+    def _prepare_arguments_doc(self, operation, _app, spec):
         # OAS 2
-        if openapi_version.major < 3:
+        if spec.openapi_version.major < 3:
             if 'parameters' in operation:
                 for param in operation['parameters']:
                     if param['in'] in (

--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -65,6 +65,11 @@ class ArgumentsMixin:
         if description is not None:
             parameters['description'] = description
 
+        error_status_code = kwargs.get(
+            'error_status_code',
+            self.ARGUMENTS_PARSER.DEFAULT_VALIDATION_STATUS
+        )
+
         def decorator(func):
 
             @wraps(func)
@@ -76,6 +81,9 @@ class ArgumentsMixin:
             wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
             docs = wrapper._apidoc.setdefault('arguments', {})
             docs.setdefault('parameters', []).append(parameters)
+            docs.setdefault('responses', {})[
+                error_status_code
+            ] = 'UnprocessableEntity'
 
             # Call use_args (from webargs) to inject params in function
             return self.ARGUMENTS_PARSER.use_args(

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -87,6 +87,7 @@ class Blueprint(
             self._prepare_arguments_doc,
             self._prepare_response_doc,
             self._prepare_pagination_doc,
+            self._prepare_etag_doc,
         ]
 
     def route(self, rule, *, parameters=None, **options):

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -193,7 +193,7 @@ class Blueprint(
             doc = OrderedDict()
             for method_l, endpoint_doc in endpoint_auto_doc.items():
                 for func in self._prepare_doc_cbks:
-                    func(endpoint_doc, spec.openapi_version)
+                    func(endpoint_doc, app, spec)
                 # Tag all operations with Blueprint name
                 endpoint_doc['tags'] = [self.name]
                 # Merge auto_doc and manual_doc into doc

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -15,26 +15,23 @@ Documentation process works in several steps:
   - When a MethodView or a view function is decorated, relevant information
     is automatically added to the object's ``_apidoc`` attribute.
 
-  - The ``Blueprint.doc`` decorator stores additional information in a separate
-    ``_api_manual_doc``. It allows the user to specify documentation
-    information that flask-smorest can not - or does not yet - infer from the
-    code.
+  - The ``Blueprint.doc`` decorator stores additional information in there that
+    flask-smorest can not - or does not yet - infer from the code.
 
   - The ``Blueprint.route`` decorator registers the endpoint in the Blueprint
-    and gathers all information about the endpoint in
-    ``Blueprint._auto_docs[endpoint]`` and
-    ``Blueprint._manual_docs[endpoint]``.
+    and gathers all documentation information about the endpoint in
+    ``Blueprint._docs[endpoint]``.
 
 - At initialization time
 
   - Schema instances are replaced by their reference in the `schemas` section
     of the spec components.
 
-  - Automatic documentation is finalized using the information stored in
-    ``Blueprint._auto_docs``, with adaptations to parameters only known at init
+  - Documentation is finalized using the information stored in
+    ``Blueprint._docs``, with adaptations to parameters only known at init
     time, such as OAS version.
 
-  - Automatic documentation is deep-merged with manual documentation.
+  - Manual documentation is deep-merged with automatic documentation.
 
   - Endpoints documentation is registered in the APISpec object.
 """
@@ -84,12 +81,12 @@ class Blueprint(
         #     },
         #     ...
         # }
-        self._auto_docs = OrderedDict()
-        self._manual_docs = OrderedDict()
+        self._docs = OrderedDict()
         self._endpoints = []
         self._prepare_doc_cbks = [
             self._prepare_arguments_doc,
             self._prepare_response_doc,
+            self._prepare_pagination_doc,
         ]
 
     def route(self, rule, *, parameters=None, **options):
@@ -135,28 +132,17 @@ class Blueprint(
     def _store_endpoint_docs(self, endpoint, obj, parameters, **options):
         """Store view or function doc info"""
 
-        endpoint_auto_doc = self._auto_docs.setdefault(
-            endpoint, OrderedDict())
-        endpoint_manual_doc = self._manual_docs.setdefault(
-            endpoint, OrderedDict())
+        endpoint_doc_info = self._docs.setdefault(endpoint, OrderedDict())
 
         def store_method_docs(method, function):
             """Add auto and manual doc to table for later registration"""
-            # Get auto documentation from decorators
+            # Get documentation from decorators
             # and summary/description from docstring
-            # Get manual documentation from @doc decorator
-            auto_doc = getattr(function, '_apidoc', {})
-            auto_doc.update(
-                load_info_from_docstring(
-                    function.__doc__,
-                    delimiter=self.DOCSTRING_INFO_DELIMITER
-                )
-            )
-            manual_doc = getattr(function, '_api_manual_doc', {})
-            # Store function auto and manual docs for later registration
-            method_l = method.lower()
-            endpoint_auto_doc[method_l] = auto_doc
-            endpoint_manual_doc[method_l] = manual_doc
+            doc = getattr(function, '_apidoc', {})
+            doc['docstring'] = load_info_from_docstring(
+                function.__doc__, delimiter=self.DOCSTRING_INFO_DELIMITER)
+            # Store function doc infos for later processing/registration
+            endpoint_doc_info[method.lower()] = doc
 
         # MethodView (class)
         if isinstance(obj, MethodViewType):
@@ -170,7 +156,8 @@ class Blueprint(
             for method in methods:
                 store_method_docs(method, obj)
 
-        endpoint_auto_doc['parameters'] = parameters
+        # Store parameters doc info from route decorator
+        endpoint_doc_info['parameters'] = parameters
 
     def register_views_in_doc(self, app, spec):
         """Register views information in documentation
@@ -182,23 +169,25 @@ class Blueprint(
         "schema":{"$ref": "#/components/schemas/MySchema"}
         """
         # This method uses the documentation information associated with each
-        # endpoint in self._[auto|manual]_docs to provide documentation for
-        # corresponding route to the spec object.
-        # Deepcopy to avoid mutating the source
-        # Allows registering blueprint multiple times (e.g. when creating
-        # multiple apps during tests)
-        auto_docs = deepcopy(self._auto_docs)
-        for endpoint, endpoint_auto_doc in auto_docs.items():
-            parameters = endpoint_auto_doc.pop('parameters')
+        # endpoint in self._docs to provide documentation for corresponding
+        # route to the spec object.
+        # Deepcopy to avoid mutating the source. Allows registering blueprint
+        # multiple times (e.g. when creating multiple apps during tests).
+        for endpoint, endpoint_doc_info in deepcopy(self._docs).items():
+            parameters = endpoint_doc_info.pop('parameters')
             doc = OrderedDict()
-            for method_l, endpoint_doc in endpoint_auto_doc.items():
+            # Use doc info stored by decorators to generate doc
+            for method_l, operation_doc_info in endpoint_doc_info.items():
+                operation_doc = {}
                 for func in self._prepare_doc_cbks:
-                    func(endpoint_doc, app, spec)
+                    operation_doc = func(
+                        operation_doc, operation_doc_info, app, spec)
+                operation_doc.update(operation_doc_info['docstring'])
                 # Tag all operations with Blueprint name
-                endpoint_doc['tags'] = [self.name]
-                # Merge auto_doc and manual_doc into doc
-                manual_doc = self._manual_docs[endpoint][method_l]
-                doc[method_l] = deepupdate(endpoint_doc, manual_doc)
+                operation_doc['tags'] = [self.name]
+                # Complete doc with manual doc info
+                manual_doc = operation_doc_info.get('manual_doc', {})
+                doc[method_l] = deepupdate(operation_doc, manual_doc)
 
             # Thanks to self.route, there can only be one rule per endpoint
             full_endpoint = '.'.join((self.name, endpoint))
@@ -225,11 +214,10 @@ class Blueprint(
             def wrapper(*f_args, **f_kwargs):
                 return func(*f_args, **f_kwargs)
 
-            # Don't merge manual doc with auto-documentation right now.
-            # Store it in a separate attribute to merge it later.
             # The deepcopy avoids modifying the wrapped function doc
-            wrapper._api_manual_doc = deepupdate(
-                deepcopy(getattr(wrapper, '_api_manual_doc', {})), kwargs)
+            wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
+            wrapper._apidoc['manual_doc'] = deepupdate(
+                deepcopy(wrapper._apidoc.get('manual_doc', {})), kwargs)
             return wrapper
 
         return decorator

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -27,8 +27,8 @@ Documentation process works in several steps:
 
 - At initialization time
 
-  - Schema instances are replaced either by their reference in the `schemas`
-    section of the spec if applicable, otherwise by their json representation.
+  - Schema instances are replaced by their reference in the `schemas` section
+    of the spec components.
 
   - Automatic documentation is adapted to OpenAPI version and deep-merged with
     manual documentation.

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -181,7 +181,12 @@ class Blueprint(
                 operation_doc = {}
                 for func in self._prepare_doc_cbks:
                     operation_doc = func(
-                        operation_doc, operation_doc_info, app, spec)
+                        operation_doc,
+                        operation_doc_info,
+                        app=app,
+                        spec=spec,
+                        method=method_l
+                    )
                 operation_doc.update(operation_doc_info['docstring'])
                 # Tag all operations with Blueprint name
                 operation_doc['tags'] = [self.name]

--- a/flask_smorest/error_handler.py
+++ b/flask_smorest/error_handler.py
@@ -1,10 +1,25 @@
 """Exception handler"""
 
 from werkzeug.exceptions import HTTPException
+import marshmallow as ma
+
+
+class ErrorSchema(ma.Schema):
+    """Schema describing the error payload
+
+    Not actually used to dump payload, but only for documentation purposes
+    """
+    code = ma.fields.Integer(description='Error code')
+    status = ma.fields.String(description='Error name')
+    message = ma.fields.String(description='Error message')
+    errors = ma.fields.Dict(description='Errors')
 
 
 class ErrorHandlerMixin:
     """Extend Api to manage error handling."""
+
+    # Should match payload structure in handle_http_exception
+    ERROR_SCHEMA = ErrorSchema
 
     def _register_error_handlers(self):
         """Register error handlers in Flask app

--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -2,6 +2,7 @@
 
 from functools import wraps
 from copy import deepcopy
+import http
 
 import hashlib
 
@@ -254,10 +255,10 @@ class EtagMixin:
             responses = {}
             method_u = method.upper()
             if method_u in self.METHODS_CHECKING_NOT_MODIFIED:
-                responses[309] = 'NotModified'
+                responses[304] = http.HTTPStatus(304).phrase
             if method_u in self.METHODS_NEEDING_CHECK_ETAG:
-                responses[412] = 'PreconditionFailed'
-                responses[428] = 'PreconditionRequired'
+                responses[412] = http.HTTPStatus(412).phrase
+                responses[428] = http.HTTPStatus(428).phrase
             if responses:
                 doc = deepupdate(doc, {'responses': responses})
         return doc

--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -1,6 +1,7 @@
 """ETag feature"""
 
 from functools import wraps
+from copy import deepcopy
 
 import hashlib
 
@@ -10,7 +11,7 @@ from flask import request, current_app, json
 from .exceptions import (
     CheckEtagNotCalledError,
     PreconditionRequired, PreconditionFailed, NotModified)
-from .utils import get_appcontext
+from .utils import deepupdate, get_appcontext
 from .compat import MARSHMALLOW_VERSION_MAJOR
 
 
@@ -90,6 +91,11 @@ class EtagMixin:
                     self._set_etag_in_response(resp, etag_schema)
 
                 return resp
+
+            # Note function is decorated by etag in doc info
+            # The deepcopy avoids modifying the wrapped function doc
+            wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
+            wrapper._apidoc['etag'] = True
 
             return wrapper
 
@@ -239,3 +245,19 @@ class EtagMixin:
                     etag_data, etag_schema, extra_data)
                 self._check_not_modified(new_etag)
             response.set_etag(new_etag)
+
+    def _prepare_etag_doc(self, doc, doc_info, app, method, **kwargs):
+        if (
+                doc_info.get('etag', False) and
+                not app.config.get('ETAG_DISABLED', False)
+        ):
+            responses = {}
+            method_u = method.upper()
+            if method_u in self.METHODS_CHECKING_NOT_MODIFIED:
+                responses[309] = 'NotModified'
+            if method_u in self.METHODS_NEEDING_CHECK_ETAG:
+                responses[412] = 'PreconditionFailed'
+                responses[428] = 'PreconditionRequired'
+            if responses:
+                doc = deepupdate(doc, {'responses': responses})
+        return doc

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -229,7 +229,7 @@ class PaginationMixin:
         return json.dumps(page_header)
 
     @staticmethod
-    def _prepare_pagination_doc(doc, doc_info, _app, _spec):
+    def _prepare_pagination_doc(doc, doc_info, **kwargs):
         operation = doc_info.get('pagination', {})
         parameters = operation.get('parameters')
         if parameters:

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -139,6 +139,11 @@ class PaginationMixin:
     DEFAULT_PAGINATION_PARAMETERS = {
         'page': 1, 'page_size': 10, 'max_page_size': 100}
 
+    PAGINATION_HEADER_DOC = {
+        'description': 'Pagination metadata',
+        'schema': PaginationHeaderSchema,
+    }
+
     def paginate(self, pager=None, *,
                  page=None, page_size=None, max_page_size=None):
         """Decorator adding pagination to the endpoint
@@ -212,6 +217,7 @@ class PaginationMixin:
             # Add pagination params to doc info in wrapper object
             wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
             wrapper._apidoc['pagination'] = {'parameters': parameters}
+            wrapper._paginated = True
 
             return wrapper
 

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -9,6 +9,7 @@ Two pagination modes are supported:
   a pager is provided to paginate the data and get the total number of items.
 """
 
+from copy import deepcopy
 from collections import OrderedDict
 from functools import wraps
 import json
@@ -156,9 +157,6 @@ class PaginationMixin:
         }
 
         def decorator(func):
-            # Add pagination params to doc info in function object
-            func._apidoc = getattr(func, '_apidoc', {})
-            func._apidoc.setdefault('parameters', []).append(parameters)
 
             @wraps(func)
             def wrapper(*args, **kwargs):
@@ -194,6 +192,10 @@ class PaginationMixin:
 
                 return result, status, headers
 
+            # Add pagination params to doc info in wrapper object
+            wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
+            wrapper._apidoc['pagination'] = {'parameters': parameters}
+
             return wrapper
 
         return decorator
@@ -225,3 +227,11 @@ class PaginationMixin:
                 if page < last_page:
                     page_header['next_page'] = page + 1
         return json.dumps(page_header)
+
+    @staticmethod
+    def _prepare_pagination_doc(doc, doc_info, _app, _spec):
+        operation = doc_info.get('pagination', {})
+        parameters = operation.get('parameters')
+        if parameters:
+            doc.setdefault('parameters', []).append(parameters)
+        return doc

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -12,7 +12,6 @@ Two pagination modes are supported:
 from copy import deepcopy
 from collections import OrderedDict
 from functools import wraps
-import json
 
 from flask import request, current_app
 
@@ -108,6 +107,24 @@ class Page:
         return ("{}(collection={!r},page_params={!r})"
                 .format(self.__class__.__name__,
                         self.collection, self.page_params))
+
+
+class PaginationHeaderSchema(ma.Schema):
+    """Pagination header schema
+
+    Used to serialize pagination header.
+    Its main purpose is to document the pagination header.
+    """
+    total = ma.fields.Int()
+    total_pages = ma.fields.Int()
+    first_page = ma.fields.Int()
+    last_page = ma.fields.Int()
+    page = ma.fields.Int()
+    previous_page = ma.fields.Int()
+    next_page = ma.fields.Int()
+
+    class Meta:
+        ordered = True
 
 
 class PaginationMixin:
@@ -226,7 +243,7 @@ class PaginationMixin:
                     page_header['previous_page'] = page - 1
                 if page < last_page:
                     page_header['next_page'] = page + 1
-        return json.dumps(page_header)
+        return PaginationHeaderSchema().dumps(page_header)
 
     @staticmethod
     def _prepare_pagination_doc(doc, doc_info, **kwargs):

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -145,7 +145,7 @@ class ResponseMixin:
         return data
 
     @staticmethod
-    def _prepare_response_doc(doc, doc_info, _app, spec):
+    def _prepare_response_doc(doc, doc_info, spec, **kwargs):
         operation = doc_info.get('response', {})
         # OAS 2
         if spec.openapi_version.major < 3:

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -114,9 +114,10 @@ class ResponseMixin:
 
         return decorator
 
-    def _prepare_response_doc(self, operation, openapi_version):
+    @staticmethod
+    def _prepare_response_doc(operation, _app, spec):
         # OAS 2
-        if openapi_version.major < 3:
+        if spec.openapi_version.major < 3:
             if 'responses' in operation:
                 for resp in operation['responses'].values():
                     if 'example' in resp:

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -67,6 +67,7 @@ class ResponseMixin:
             resp_doc['examples'] = examples
         if headers is not None:
             resp_doc['headers'] = headers
+        doc = {'responses': {code: resp_doc}}
 
         def decorator(func):
 
@@ -104,10 +105,18 @@ class ResponseMixin:
 
                 return resp
 
+            # Document pagination header if needed
+            if getattr(func, '_paginated', False) is True:
+                doc['responses'][code]['headers'] = {
+                    self.PAGINATION_HEADER_FIELD_NAME: (
+                        self.PAGINATION_HEADER_DOC
+                    )
+                }
+
             # Store doc in wrapper function
             # The deepcopy avoids modifying the wrapped function doc
             wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
-            wrapper._apidoc['response'] = {'responses': {code: resp_doc}}
+            wrapper._apidoc['response'] = doc
 
             return wrapper
 

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -114,6 +114,9 @@ class ResponseMixin:
                     )
                 }
 
+            # Document default error response
+            doc['responses']['default'] = 'DefaultError'
+
             # Store doc in wrapper function
             # The deepcopy avoids modifying the wrapped function doc
             wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -115,7 +115,7 @@ class ResponseMixin:
                 }
 
             # Document default error response
-            doc['responses']['default'] = 'DefaultError'
+            doc['responses']['default'] = 'Default Error'
 
             # Store doc in wrapper function
             # The deepcopy avoids modifying the wrapped function doc

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -67,7 +67,6 @@ class ResponseMixin:
             resp_doc['examples'] = examples
         if headers is not None:
             resp_doc['headers'] = headers
-        doc = {'responses': {code: resp_doc}}
 
         def decorator(func):
 
@@ -107,34 +106,12 @@ class ResponseMixin:
 
             # Store doc in wrapper function
             # The deepcopy avoids modifying the wrapped function doc
-            wrapper._apidoc = deepupdate(
-                deepcopy(getattr(wrapper, '_apidoc', {})), doc)
+            wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
+            wrapper._apidoc['response'] = {'responses': {code: resp_doc}}
 
             return wrapper
 
         return decorator
-
-    @staticmethod
-    def _prepare_response_doc(operation, _app, spec):
-        # OAS 2
-        if spec.openapi_version.major < 3:
-            if 'responses' in operation:
-                for resp in operation['responses'].values():
-                    if 'example' in resp:
-                        resp['examples'] = {
-                            DEFAULT_RESPONSE_CONTENT_TYPE: resp.pop('example')}
-        # OAS 3
-        else:
-            if 'responses' in operation:
-                for resp in operation['responses'].values():
-                    for field in ('schema', 'example', 'examples'):
-                        if field in resp:
-                            (
-                                resp
-                                .setdefault('content', {})
-                                .setdefault(DEFAULT_RESPONSE_CONTENT_TYPE, {})
-                                [field]
-                            ) = resp.pop(field)
 
     @staticmethod
     def _make_doc_response_schema(schema):
@@ -166,3 +143,28 @@ class ResponseMixin:
                     return {'type': 'success', 'data': schema}
         """
         return data
+
+    @staticmethod
+    def _prepare_response_doc(doc, doc_info, _app, spec):
+        operation = doc_info.get('response', {})
+        # OAS 2
+        if spec.openapi_version.major < 3:
+            if 'responses' in operation:
+                for resp in operation['responses'].values():
+                    if 'example' in resp:
+                        resp['examples'] = {
+                            DEFAULT_RESPONSE_CONTENT_TYPE: resp.pop('example')}
+        # OAS 3
+        else:
+            if 'responses' in operation:
+                for resp in operation['responses'].values():
+                    for field in ('schema', 'example', 'examples'):
+                        if field in resp:
+                            (
+                                resp
+                                .setdefault('content', {})
+                                .setdefault(DEFAULT_RESPONSE_CONTENT_TYPE, {})
+                                [field]
+                            ) = resp.pop(field)
+        doc = deepupdate(doc, operation)
+        return doc

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -1,5 +1,6 @@
 """API specification using OpenAPI"""
 import json
+import http
 
 import flask
 from flask import current_app
@@ -7,6 +8,7 @@ import apispec
 from apispec.ext.marshmallow import MarshmallowPlugin
 
 from flask_smorest.exceptions import OpenAPIVersionNotSpecified
+from flask_smorest.utils import prepare_response
 from .plugins import FlaskPlugin
 from .field_converters import uploadfield2properties
 
@@ -269,3 +271,24 @@ class APISpecMixin(DocBlueprintMixin):
 
     def _register_field(self, field, *args):
         self.ma_plugin.map_to_openapi_type(*args)(field)
+
+    def _register_default_error_response(self):
+        """Register default error response"""
+        response = {
+            'description': 'Default error response',
+            'schema': self.ERROR_SCHEMA,
+        }
+        prepare_response(response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
+        self.spec.components.response('Default Error', response)
+
+    def _register_default_response_by_code(self, code):
+        """Register a default response for a given status code
+
+        :param int|HTTPStatus code: Status code
+        """
+        response = {
+            'description': http.HTTPStatus(code).phrase,
+            'schema': self.ERROR_SCHEMA,
+        }
+        prepare_response(response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
+        self.spec.components.response(http.HTTPStatus(code).phrase, response)

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -272,23 +272,22 @@ class APISpecMixin(DocBlueprintMixin):
     def _register_field(self, field, *args):
         self.ma_plugin.map_to_openapi_type(*args)(field)
 
-    def _register_default_error_response(self):
-        """Register default error response"""
+    def _register_responses(self):
+        """Register default responses for all status codes"""
+        # Register a response for each status code
+        for status in http.HTTPStatus:
+            response = {
+                'description': status.phrase,
+                'schema': self.ERROR_SCHEMA,
+            }
+            prepare_response(
+                response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
+            self.spec.components.response(status.phrase, response)
+
+        # Also register a default error response
         response = {
             'description': 'Default error response',
             'schema': self.ERROR_SCHEMA,
         }
         prepare_response(response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
         self.spec.components.response('Default Error', response)
-
-    def _register_default_response_by_code(self, code):
-        """Register a default response for a given status code
-
-        :param int|HTTPStatus code: Status code
-        """
-        response = {
-            'description': http.HTTPStatus(code).phrase,
-            'schema': self.ERROR_SCHEMA,
-        }
-        prepare_response(response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
-        self.spec.components.response(http.HTTPStatus(code).phrase, response)

--- a/flask_smorest/utils.py
+++ b/flask_smorest/utils.py
@@ -110,3 +110,23 @@ def set_status_and_headers_in_response(response, status, headers):
             response.status_code = status
         else:
             response.status = status
+
+
+def prepare_response(response, spec, default_response_content_type):
+    """Rework response according to OAS version"""
+    # OAS 2
+    if spec.openapi_version.major < 3:
+        if 'example' in response:
+            response['examples'] = {
+                default_response_content_type: response.pop('example')
+            }
+    # OAS 3
+    else:
+        for field in ('schema', 'example', 'examples'):
+            if field in response:
+                (
+                    response
+                    .setdefault('content', {})
+                    .setdefault(default_response_content_type, {})
+                    [field]
+                ) = response.pop(field)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ import apispec
 from flask_smorest import Api, Blueprint
 from flask_smorest.exceptions import OpenAPIVersionNotSpecified
 
-from .utils import get_schemas
+from .utils import get_schemas, get_responses
 
 
 class TestApi():
@@ -264,3 +264,12 @@ class TestApi():
                 match='The OpenAPI version must be specified'
         ):
             Api(app)
+
+    @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
+    def test_api_registers_error_responses(self, app, openapi_version):
+        """Test default errors are registered"""
+        app.config['OPENAPI_VERSION'] = openapi_version
+        api = Api(app)
+        assert 'Error' in get_schemas(api.spec)
+        assert 'DefaultError' in get_responses(api.spec)
+        assert 'UnprocessableEntity' in get_responses(api.spec)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -284,6 +284,9 @@ class TestApi():
         app.config['ETAG_DISABLED'] = not etag_enabled
         api = Api(app)
         assert (
+            ('NotModified' in get_responses(api.spec)) == etag_enabled
+        )
+        assert (
             ('PreconditionRequired' in get_responses(api.spec)) == etag_enabled
         )
         assert (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -271,8 +271,8 @@ class TestApi():
         app.config['OPENAPI_VERSION'] = openapi_version
         api = Api(app)
         assert 'Error' in get_schemas(api.spec)
-        assert 'DefaultError' in get_responses(api.spec)
-        assert 'UnprocessableEntity' in get_responses(api.spec)
+        assert 'Default Error' in get_responses(api.spec)
+        assert 'Unprocessable Entity' in get_responses(api.spec)
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
     @pytest.mark.parametrize('etag_enabled', [True, False])
@@ -284,11 +284,13 @@ class TestApi():
         app.config['ETAG_DISABLED'] = not etag_enabled
         api = Api(app)
         assert (
-            ('NotModified' in get_responses(api.spec)) == etag_enabled
+            ('Not Modified' in get_responses(api.spec)) == etag_enabled
         )
         assert (
-            ('PreconditionRequired' in get_responses(api.spec)) == etag_enabled
+            ('Precondition Required' in get_responses(api.spec)) ==
+            etag_enabled
         )
         assert (
-            ('PreconditionFailed' in get_responses(api.spec)) == etag_enabled
+            ('Precondition Failed' in get_responses(api.spec)) ==
+            etag_enabled
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -267,9 +267,25 @@ class TestApi():
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
     def test_api_registers_error_responses(self, app, openapi_version):
-        """Test default errors are registered"""
+        """Test default error responses are registered"""
         app.config['OPENAPI_VERSION'] = openapi_version
         api = Api(app)
         assert 'Error' in get_schemas(api.spec)
         assert 'DefaultError' in get_responses(api.spec)
         assert 'UnprocessableEntity' in get_responses(api.spec)
+
+    @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
+    @pytest.mark.parametrize('etag_enabled', [True, False])
+    def test_api_registers_etag_error_responses(
+            self, app, openapi_version, etag_enabled
+    ):
+        """Test ETag error responses are registered iif ETag is enabled"""
+        app.config['OPENAPI_VERSION'] = openapi_version
+        app.config['ETAG_DISABLED'] = not etag_enabled
+        api = Api(app)
+        assert (
+            ('PreconditionRequired' in get_responses(api.spec)) == etag_enabled
+        )
+        assert (
+            ('PreconditionFailed' in get_responses(api.spec)) == etag_enabled
+        )

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -369,6 +369,25 @@ class TestBlueprint():
         )
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
+    def test_blueprint_arguments_document_422_error(
+            self, app, schemas, openapi_version
+    ):
+        app.config['OPENAPI_VERSION'] = openapi_version
+        api = Api(app)
+        blp = Blueprint('test', __name__, url_prefix='/test')
+
+        @blp.route('/')
+        @blp.arguments(schemas.DocSchema)
+        def func():
+            """Dummy view func"""
+
+        api.register_blueprint(blp)
+        spec = api.spec.to_dict()
+        assert spec['paths']['/test/']['get']['responses']['422'] == build_ref(
+            api.spec, 'response', 'UnprocessableEntity'
+        )
+
+    @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
     def test_blueprint_route_parameters(self, app, openapi_version):
         """Check path parameters docs are merged with auto docs"""
         app.config['OPENAPI_VERSION'] = openapi_version

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -581,6 +581,22 @@ class TestBlueprint():
         get = api.spec.to_dict()['paths']['/test/']['get']
         assert get['responses']['200']['headers'] == headers
 
+    def test_blueprint_response_default_error(self, app):
+        api = Api(app)
+        blp = Blueprint('test', 'test', url_prefix='/test')
+
+        @blp.route('/')
+        @blp.response()
+        def func():
+            pass
+
+        api.register_blueprint(blp)
+
+        get = api.spec.to_dict()['paths']['/test/']['get']
+        assert get['responses']['default'] == build_ref(
+            api.spec, 'response', 'DefaultError'
+        )
+
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
     def test_blueprint_pagination(self, app, schemas, openapi_version):
         app.config['OPENAPI_VERSION'] = openapi_version

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -579,38 +579,37 @@ class TestBlueprint():
 
         # Check parameters are documented
         parameters = spec['paths']['/test/']['get']['parameters']
-        # Page
-        assert parameters[0]['name'] == 'page'
+        # Query string parameters
+        assert parameters[0]['name'] == 'arg1'
         assert parameters[0]['in'] == 'query'
-        assert parameters[0]['required'] is False
-        if openapi_version == '2.0':
-            assert parameters[0]['type'] == 'integer'
-            assert parameters[0]['default'] == 1
-            assert parameters[0]['minimum'] == 1
-        else:
-            assert parameters[0]['schema']['type'] == 'integer'
-            assert parameters[0]['schema']['default'] == 1
-            assert parameters[0]['schema']['minimum'] == 1
-        # Page size
-        assert parameters[1]['name'] == 'page_size'
+        assert parameters[1]['name'] == 'arg2'
         assert parameters[1]['in'] == 'query'
-        assert parameters[1]['required'] is False
-        if openapi_version == '2.0':
-            assert parameters[1]['type'] == 'integer'
-            assert parameters[1]['default'] == 10
-            assert parameters[1]['minimum'] == 1
-            assert parameters[1]['maximum'] == 100
-        else:
-            assert parameters[1]['schema']['type'] == 'integer'
-            assert parameters[1]['schema']['default'] == 10
-            assert parameters[1]['schema']['minimum'] == 1
-            assert parameters[1]['schema']['maximum'] == 100
-        # Other query string parameters
-        assert parameters[1]['in'] == 'query'
-        assert parameters[2]['name'] == 'arg1'
+        # Page
+        assert parameters[2]['name'] == 'page'
         assert parameters[2]['in'] == 'query'
-        assert parameters[3]['name'] == 'arg2'
+        assert parameters[2]['required'] is False
+        if openapi_version == '2.0':
+            assert parameters[2]['type'] == 'integer'
+            assert parameters[2]['default'] == 1
+            assert parameters[2]['minimum'] == 1
+        else:
+            assert parameters[2]['schema']['type'] == 'integer'
+            assert parameters[2]['schema']['default'] == 1
+            assert parameters[2]['schema']['minimum'] == 1
+        # Page size
+        assert parameters[3]['name'] == 'page_size'
         assert parameters[3]['in'] == 'query'
+        assert parameters[3]['required'] is False
+        if openapi_version == '2.0':
+            assert parameters[3]['type'] == 'integer'
+            assert parameters[3]['default'] == 10
+            assert parameters[3]['minimum'] == 1
+            assert parameters[3]['maximum'] == 100
+        else:
+            assert parameters[3]['schema']['type'] == 'integer'
+            assert parameters[3]['schema']['default'] == 10
+            assert parameters[3]['schema']['minimum'] == 1
+            assert parameters[3]['schema']['maximum'] == 100
 
     def test_blueprint_doc_function(self, app):
         api = Api(app)

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -384,7 +384,7 @@ class TestBlueprint():
         api.register_blueprint(blp)
         spec = api.spec.to_dict()
         assert spec['paths']['/test/']['get']['responses']['422'] == build_ref(
-            api.spec, 'response', 'UnprocessableEntity'
+            api.spec, 'response', 'Unprocessable Entity'
         )
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
@@ -594,7 +594,7 @@ class TestBlueprint():
 
         get = api.spec.to_dict()['paths']['/test/']['get']
         assert get['responses']['default'] == build_ref(
-            api.spec, 'response', 'DefaultError'
+            api.spec, 'response', 'Default Error'
         )
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
@@ -1074,11 +1074,11 @@ class TestBlueprint():
         responses = operation.get('responses', {})
 
         if not decorate or etag_disabled:
-            assert '309' not in responses
+            assert '304' not in responses
             assert '412' not in responses
             assert '428' not in responses
         else:
-            assert ('309' in responses) == (method in ['GET', 'HEAD'])
+            assert ('304' in responses) == (method in ['GET', 'HEAD'])
             assert ('412' in responses) == (
                 method in ['PUT', 'PATCH', 'DELETE'])
             assert ('428' in responses) == (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,18 @@
 from apispec.utils import build_reference
 
 
+# Getter functions are copied from apispec tests
+
 def get_schemas(spec):
     if spec.openapi_version.major < 3:
         return spec.to_dict()["definitions"]
     return spec.to_dict()["components"]["schemas"]
+
+
+def get_responses(spec):
+    if spec.openapi_version.major < 3:
+        return spec.to_dict()["responses"]
+    return spec.to_dict()["components"]["responses"]
 
 
 def build_ref(spec, component_type, obj):


### PR DESCRIPTION
This PR brings automatic documentation of

- default errors
- pagination feature
- ETag feature (WIP)

It is based on #123 as the _prepare_doc rework will be needed to document ETag correctly.

I've been testing this on an app of ours and the result in ReDoc was neat. It still needs a bit of work on ETag to ensure it is documented only if enabled.

There are things I'm not 100% happy about but that's life. I've been holding this for month and it is better than nothing, yet.

One of my concerns is the mixins not being totally independent but there's nothing to do about that, I'm afraid.

Feedback welcome.