### PR TITLE
Move to webargs 6.0.0

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -76,6 +76,64 @@ view function.
         def post(pet_data, query_args):
             return Pet.create(pet_data, **query_args)
 
+Multiple Arguments Schemas
+--------------------------
+
+To define arguments from multiple locations, calls to ``arguments`` decorator
+can be stacked:
+
+.. code-block:: python
+    :emphasize-lines: 4,5
+
+    @blp.route('/')
+    class Pets(MethodView):
+
+        @blp.arguments(PetSchema)
+        @blp.arguments(QueryArgsSchema, location="query")
+        @blp.response(PetSchema, code=201)
+        def post(self, pet_data, query_args):
+            pet = Pet.create(**pet_data)
+            # Use query args
+            ...
+            return pet
+
+It is possible to define multiple arguments for the same location. However,
+with marshmallow 3, schemas raise by default on unknown fields, so they should
+be tweaked to define ``unknown`` meta attribute as ``EXCLUDE``.
+
+.. code-block:: python
+    :emphasize-lines: 5,12
+
+    # With marshmallow 3, define unknown=EXCLUDE
+    class QueryArgsSchema1(ma.Schema):
+        class Meta:
+            ordered = True
+            unknown = ma.EXCLUDE
+        arg1 = ma.fields.String()
+        arg2 = ma.fields.Integer()
+
+    class QueryArgsSchema2(ma.Schema):
+        class Meta:
+            ordered = True
+            unknown = ma.EXCLUDE
+        arg3 = ma.fields.String()
+        arg4 = ma.fields.Integer()
+
+    @blp.route('/')
+    class Pets(MethodView):
+
+        @blp.arguments(QueryArgsSchema1, location="query")
+        @blp.arguments(QueryArgsSchema2, location="query")
+        @blp.response(PetSchema, code=201)
+        def get(self, query_args_1, query_args_2):
+            query = {}
+            query.update(query_args_1)
+            query.update(query_args_2)
+            return Pet.get(**query)
+
+This also applies when using both query arguments and ``pagination`` decorator,
+as the pagination feature uses query arguments for pagination parameters.
+
 Content Type
 ------------
 

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -42,11 +42,6 @@ The following locations are allowed:
 
 The location defaults to ``"json"``, which means `body` parameter.
 
-.. note:: :meth:`Blueprint.arguments <Blueprint.arguments>` uses webargs's
-   :meth:`use_args <webargs.core.Parser.use_args>` decorator internally, but   
-   unlike :meth:`use_args <webargs.core.Parser.use_args>`, it only accepts a
-   single location.
-
 Arguments Injection
 -------------------
 

--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -87,7 +87,7 @@ class ArgumentsMixin:
 
             # Call use_args (from webargs) to inject params in function
             return self.ARGUMENTS_PARSER.use_args(
-                schema, locations=[location], **kwargs)(wrapper)
+                schema, location=location, **kwargs)(wrapper)
 
         return decorator
 

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -188,7 +188,7 @@ class PaginationMixin:
             def wrapper(*args, **kwargs):
 
                 page_params = self.PAGINATION_ARGUMENTS_PARSER.parse(
-                    page_params_schema, request, locations=['query'])
+                    page_params_schema, request, location='query')
 
                 # Pagination in resource code: inject page_params as kwargs
                 if pager is None:

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -60,6 +60,8 @@ def _pagination_parameters_schema_factory(
             ordered = True
             if MARSHMALLOW_VERSION_MAJOR < 3:
                 strict = True
+            else:
+                unknown = ma.EXCLUDE
 
         page = ma.fields.Integer(
             missing=def_page,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'werkzeug>=0.15',
         'flask>=1.1.0',
         'marshmallow>=2.15.2',
-        'webargs>=1.5.2,<6.0.0',
+        'webargs>=6.0.0',
         'apispec>=3.0.0',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 
-from marshmallow import Schema, fields, post_load, post_dump
+import marshmallow as ma
 
 from flask import Flask
 
@@ -34,7 +34,7 @@ def app(request):
     return _app
 
 
-class CounterSchema(Schema):
+class CounterSchema(ma.Schema):
     """Base Schema with load/dump counters"""
 
     load_count = 0
@@ -48,12 +48,12 @@ class CounterSchema(Schema):
     def reset_dump_count(cls):
         cls.dump_count = 0
 
-    @post_load(pass_many=True)
+    @ma.post_load(pass_many=True)
     def increment_load_count(self, data, many, **kwargs):
         self.__class__.load_count += 1
         return data
 
-    @post_dump(pass_many=True)
+    @ma.post_dump(pass_many=True)
     def increment_dump_count(self, data, many, **kwargs):
         self.__class__.dump_count += 1
         return data
@@ -66,22 +66,24 @@ def schemas():
         if MARSHMALLOW_VERSION_MAJOR < 3:
             class Meta:
                 strict = True
-        item_id = fields.Int(dump_only=True)
-        field = fields.Int(attribute='db_field')
+        item_id = ma.fields.Int(dump_only=True)
+        field = ma.fields.Int(attribute='db_field')
 
     class DocEtagSchema(CounterSchema):
         if MARSHMALLOW_VERSION_MAJOR < 3:
             class Meta:
                 strict = True
-        field = fields.Int(attribute='db_field')
+        field = ma.fields.Int(attribute='db_field')
 
-    class QueryArgsSchema(Schema):
+    class QueryArgsSchema(ma.Schema):
         class Meta:
             ordered = True
             if MARSHMALLOW_VERSION_MAJOR < 3:
                 strict = True
-        arg1 = fields.String()
-        arg2 = fields.Integer()
+            else:
+                unknown = ma.EXCLUDE
+        arg1 = ma.fields.String()
+        arg2 = ma.fields.Integer()
 
     return namedtuple(
         'Model', ('DocSchema', 'DocEtagSchema', 'QueryArgsSchema'))(

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -339,3 +339,27 @@ class TestPagination():
             data=json.dumps({'page': 2, 'page_size': 20}),
         )
         assert response.json == list(range(0, 10))
+
+    def test_pagination_parameters_and_query_string_args(self, app, schemas):
+        api = Api(app)
+        blp = Blueprint('test', __name__, url_prefix='/test')
+
+        @blp.route('/')
+        @blp.arguments(schemas.QueryArgsSchema, location="query")
+        @blp.response()
+        @blp.paginate(Page)
+        def func(query_args):
+            assert query_args['arg1'] == 'Test'
+            assert query_args['arg2'] == 12
+            return range(30)
+
+        api.register_blueprint(blp)
+        client = app.test_client()
+
+        # Pagination params in query string: OK
+        response = client.get(
+            '/test/',
+            query_string={
+                'page': 2, 'page_size': 20, 'arg1': 'Test', 'arg2': 12}
+        )
+        assert response.json == list(range(20, 30))


### PR DESCRIPTION
Closes #117.

TODO:

- [x] Modify pagination schema as unknown=IGNORE to avoid 422ing when other query args are passed on marshmallow 3.
- [x] Investigate consistency between namespaced webargs validation errors and errors triggered from view func.