### PR TITLE
Use HTTPStatus.name rather than phrase to name errors

### DIFF
--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -83,7 +83,7 @@ class ArgumentsMixin:
             docs.setdefault('parameters', []).append(parameters)
             docs.setdefault('responses', {})[
                 error_status_code
-            ] = http.HTTPStatus(error_status_code).phrase
+            ] = http.HTTPStatus(error_status_code).name
 
             # Call use_args (from webargs) to inject params in function
             return self.ARGUMENTS_PARSER.use_args(

--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -255,10 +255,10 @@ class EtagMixin:
             responses = {}
             method_u = method.upper()
             if method_u in self.METHODS_CHECKING_NOT_MODIFIED:
-                responses[304] = http.HTTPStatus(304).phrase
+                responses[304] = http.HTTPStatus(304).name
             if method_u in self.METHODS_NEEDING_CHECK_ETAG:
-                responses[412] = http.HTTPStatus(412).phrase
-                responses[428] = http.HTTPStatus(428).phrase
+                responses[412] = http.HTTPStatus(412).name
+                responses[428] = http.HTTPStatus(428).name
             if responses:
                 doc = deepupdate(doc, {'responses': responses})
         return doc

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -225,7 +225,7 @@ class PaginationMixin:
                 'parameters': parameters,
                 'response': {
                     error_status_code:
-                    http.HTTPStatus(error_status_code).phrase,
+                    http.HTTPStatus(error_status_code).name,
                 }
             }
             wrapper._paginated = True

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -61,7 +61,7 @@ class ResponseMixin:
         if description is not None:
             resp_doc['description'] = description
         else:
-            resp_doc['description'] = http.HTTPStatus(int(code)).phrase
+            resp_doc['description'] = http.HTTPStatus(int(code)).name
         if example is not None:
             resp_doc['example'] = example
         if examples is not None:
@@ -115,7 +115,7 @@ class ResponseMixin:
                 }
 
             # Document default error response
-            doc['responses']['default'] = 'Default Error'
+            doc['responses']['default'] = 'DEFAULT_ERROR'
 
             # Store doc in wrapper function
             # The deepcopy avoids modifying the wrapped function doc

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -282,7 +282,7 @@ class APISpecMixin(DocBlueprintMixin):
             }
             prepare_response(
                 response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
-            self.spec.components.response(status.phrase, response)
+            self.spec.components.response(status.name, response)
 
         # Also register a default error response
         response = {
@@ -290,4 +290,4 @@ class APISpecMixin(DocBlueprintMixin):
             'schema': self.ERROR_SCHEMA,
         }
         prepare_response(response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
-        self.spec.components.response('Default Error', response)
+        self.spec.components.response('DEFAULT_ERROR', response)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -276,12 +276,12 @@ class TestApi():
         assert 'Error' in get_schemas(api.spec)
         for status in http.HTTPStatus:
             if openapi_version == '2.0':
-                assert responses[status.phrase] == {
+                assert responses[status.name] == {
                     'description': status.phrase,
                     'schema': build_ref(api.spec, 'schema', 'Error'),
                 }
             else:
-                assert responses[status.phrase] == {
+                assert responses[status.name] == {
                     'description': status.phrase,
                     'content': {
                         'application/json': {

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -397,7 +397,7 @@ class TestBlueprint():
         error_code = error_code or 400
         assert (
             spec['paths']['/test/']['get']['responses'][str(error_code)] ==
-            build_ref(api.spec, 'response', http.HTTPStatus(error_code).phrase)
+            build_ref(api.spec, 'response', http.HTTPStatus(error_code).name)
         )
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
@@ -607,7 +607,7 @@ class TestBlueprint():
 
         get = api.spec.to_dict()['paths']['/test/']['get']
         assert get['responses']['default'] == build_ref(
-            api.spec, 'response', 'Default Error'
+            api.spec, 'response', 'DEFAULT_ERROR'
         )
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
@@ -678,7 +678,7 @@ class TestBlueprint():
         spec = api.spec.to_dict()
         assert (
             spec['paths']['/test/']['get']['responses'][str(error_code)] ==
-            build_ref(api.spec, 'response', http.HTTPStatus(error_code).phrase)
+            build_ref(api.spec, 'response', http.HTTPStatus(error_code).name)
         )
 
     def test_blueprint_doc_function(self, app):


### PR DESCRIPTION
Also change `Default Error` into `DEFAULT_ERROR` for consistency.

Fixes #136.