### PR TITLE
remove inline script (csp)

### DIFF
--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -39,6 +39,7 @@ class DocBlueprintMixin:
                 __name__,
                 url_prefix=_add_leading_slash(api_url),
                 template_folder='./templates',
+                static_folder='static',
             )
             # Serve json spec at 'url_prefix/openapi.json' by default
             json_path = self._app.config.get(

--- a/flask_smorest/spec/templates/swagger_ui.html
+++ b/flask_smorest/spec/templates/swagger_ui.html
@@ -12,18 +12,10 @@
 
    <script src="{{swagger_ui_url}}swagger-ui-standalone-preset.js"></script>
    <script src="{{swagger_ui_url}}swagger-ui-bundle.js"></script>
-   <script>
-     window.onload = function() {
-       const ui = SwaggerUIBundle({
-         url: "{{ url_for('api-docs.openapi_json') }}",
-         dom_id: '#swagger-ui-container',
-         deepLinking: true,
-         layout: "BaseLayout",
-         supportedSubmitMethods: [{% for meth in swagger_ui_supported_submit_methods %}"{{meth.lower()}}",{% endfor %}],
-       })
-       window.ui = ui
-     }
-   </script>
+
+   <script id="openapi-url" type="application/json">{{ url_for('api-docs.openapi_json') }}</script>
+   <script id="supported-submit-methods" type="application/json">{{ swagger_ui_supported_submit_methods|tojson }}</script>
+   <script type="text/javascript" src={{url_for("api-docs.static", filename="js/swagger-ui-bundle.js")}}></script>
 
  </body>
 

--- a/flask_smorest/static/js/swagger-ui-bundle.js
+++ b/flask_smorest/static/js/swagger-ui-bundle.js
@@ -1,0 +1,10 @@
+window.onload = function() {
+    const ui = SwaggerUIBundle({
+        url: document.getElementById('openapi-url').textContent,
+        dom_id: '#swagger-ui-container',
+        deepLinking: true,
+        layout: "BaseLayout",
+        supportedSubmitMethods: JSON.parse(document.getElementById('supported-submit-methods').textContent),
+    })
+    window.ui = ui
+}


### PR DESCRIPTION
Move javascript code from html files into their own .js files.
This will allow servers that have set "unsafe-inline" in their content security policy header to run the js code and render the swagger docs.

My use case is what I described above, I have set the Content Security Policy header for scripts to "unsafe-inline" and it did not let any inline js code to be run.

I am not expert in html/js so please let me know if I need to change anything.
I also did not lowered the swagger submitted methods as I saw the return value was already lowered, please let me know if this is not always true.