### PR TITLE
Add test_response_payload_wrapping

### DIFF
--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -134,11 +134,14 @@ class ResponseMixin:
             Example: ::
 
                 @staticmethod
-                def _doc_schema(schema):
+                def _make_doc_response_schema(schema):
                     if schema:
-                        return {'type': 'success', 'data': schema}
-                    else:
-                        return None
+                        return type(
+                            'Wrap' + schema.__class__.__name__,
+                            (ma.Schema, ),
+                            {'data': ma.fields.Nested(schema)},
+                        )
+                    return None
         """
         return schema
 
@@ -151,8 +154,10 @@ class ResponseMixin:
             Example: ::
 
                 @staticmethod
-                def _prepare_response_content:
-                    return {'type': 'success', 'data': schema}
+                def _prepare_response_content(data):
+                    if data is not None:
+                        return {'data': data}
+                    return None
         """
         return data
 


### PR DESCRIPTION
flask-smorest uses an opinionated choice of defaults but tries to allow customization by providing hooks to define custom behaviours.

This PR adds a section in tests/test_examples.py to include tests that illustrate custom usages that we'd like to support.

Those tests serve multiple purposes:

- example: illustrate how to customize with a working example
- test: unit test the hooks
- non-regression: ensure we don't break those use cases inadvertently

------------------------------------

`test_response_payload_wrapping` demonstrates how to wrap response content in a `data` field.