### PR TITLE
Add "pagination in response payload" demo test

### DIFF
--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -273,7 +273,7 @@ class PaginationMixin:
         )
         return result, headers
 
-    def _document_pagination_metadata(self, resp_doc):
+    def _document_pagination_metadata(self, spec, resp_doc):
         """Document pagination metadata header
 
         Override this to document custom pagination metadata
@@ -285,7 +285,7 @@ class PaginationMixin:
             }
         }
 
-    def _prepare_pagination_doc(self, doc, doc_info, **kwargs):
+    def _prepare_pagination_doc(self, doc, doc_info, spec, **kwargs):
         operation = doc_info.get('pagination')
         if operation:
             parameters = operation.get('parameters')
@@ -295,5 +295,5 @@ class PaginationMixin:
             success_status_code = doc_info.get('success_status_code')
             if success_status_code is not None:
                 self._document_pagination_metadata(
-                    doc['responses'][success_status_code])
+                    spec, doc['responses'][success_status_code])
         return doc

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -142,11 +142,6 @@ class PaginationMixin:
     DEFAULT_PAGINATION_PARAMETERS = {
         'page': 1, 'page_size': 10, 'max_page_size': 100}
 
-    PAGINATION_HEADER_DOC = {
-        'description': 'Pagination metadata',
-        'schema': PaginationMetadataSchema,
-    }
-
     def paginate(self, pager=None, *,
                  page=None, page_size=None, max_page_size=None):
         """Decorator adding pagination to the endpoint
@@ -284,7 +279,10 @@ class PaginationMixin:
         Override this to document custom pagination metadata
         """
         resp_doc['headers'] = {
-            self.PAGINATION_HEADER_FIELD_NAME: self.PAGINATION_HEADER_DOC
+            self.PAGINATION_HEADER_FIELD_NAME: {
+                'description': 'Pagination metadata',
+                'schema': PaginationMetadataSchema,
+            }
         }
 
     def _prepare_pagination_doc(self, doc, doc_info, **kwargs):

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -204,20 +204,16 @@ class PaginationMixin:
                 if pager is not None:
                     result = pager(result, page_params=page_params).items
 
-                # Add pagination metadata to headers
+                # Set pagination metadata in response
                 if self.PAGINATION_HEADER_FIELD_NAME is not None:
                     if page_params.item_count is None:
                         current_app.logger.warning(
                             'item_count not set in endpoint {}'
-                            .format(request.endpoint))
+                            .format(request.endpoint)
+                        )
                     else:
-                        page_header = self._make_pagination_header(
-                            page_params.page, page_params.page_size,
-                            page_params.item_count)
-                        if headers is None:
-                            headers = {}
-                        headers[
-                            self.PAGINATION_HEADER_FIELD_NAME] = page_header
+                        result, headers = self._set_pagination_metadata(
+                            page_params, result, headers)
 
                 return result, status, headers
 
@@ -266,6 +262,19 @@ class PaginationMixin:
         if MARSHMALLOW_VERSION_MAJOR < 3:
             header = header.data
         return header
+
+    def _set_pagination_metadata(self, page_params, result, headers):
+        """Add pagination metadata to headers
+
+        Override this to set pagination data another way
+        """
+        page_header = self._make_pagination_header(
+            page_params.page, page_params.page_size,
+            page_params.item_count)
+        if headers is None:
+            headers = {}
+        headers[self.PAGINATION_HEADER_FIELD_NAME] = page_header
+        return result, headers
 
     @staticmethod
     def _prepare_pagination_doc(doc, doc_info, **kwargs):

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -226,7 +226,6 @@ class PaginationMixin:
                     http.HTTPStatus(error_status_code).name,
                 }
             }
-            wrapper._paginated = True
 
             return wrapper
 
@@ -276,12 +275,24 @@ class PaginationMixin:
         headers[self.PAGINATION_HEADER_FIELD_NAME] = page_header
         return result, headers
 
-    @staticmethod
-    def _prepare_pagination_doc(doc, doc_info, **kwargs):
+    def _document_pagination_metadata(self, resp_doc):
+        """Document pagination metadata header
+
+        Override this to document custom pagination metadata
+        """
+        resp_doc['headers'] = {
+            self.PAGINATION_HEADER_FIELD_NAME: self.PAGINATION_HEADER_DOC
+        }
+
+    def _prepare_pagination_doc(self, doc, doc_info, **kwargs):
         operation = doc_info.get('pagination')
         if operation:
             parameters = operation.get('parameters')
             doc.setdefault('parameters', []).append(parameters)
             response = operation.get('response')
             doc.setdefault('responses', {}).update(response)
+            success_status_code = doc_info.get('success_status_code')
+            if success_status_code is not None:
+                self._document_pagination_metadata(
+                    doc['responses'][success_status_code])
         return doc

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -109,11 +109,11 @@ class Page:
                         self.collection, self.page_params))
 
 
-class PaginationHeaderSchema(ma.Schema):
-    """Pagination header schema
+class PaginationMetadataSchema(ma.Schema):
+    """Pagination metadata schema
 
-    Used to serialize pagination header.
-    Its main purpose is to document the pagination header.
+    Used to serialize pagination metadata.
+    Its main purpose is to document the pagination metadata.
     """
     total = ma.fields.Int()
     total_pages = ma.fields.Int()
@@ -143,7 +143,7 @@ class PaginationMixin:
 
     PAGINATION_HEADER_DOC = {
         'description': 'Pagination metadata',
-        'schema': PaginationHeaderSchema,
+        'schema': PaginationMetadataSchema,
     }
 
     def paginate(self, pager=None, *,
@@ -232,42 +232,42 @@ class PaginationMixin:
         return decorator
 
     @staticmethod
-    def _make_pagination_header(page, page_size, item_count):
-        """Build pagination header from page, page size and item count
+    def _make_pagination_metadata(page, page_size, item_count):
+        """Build pagination metadata from page, page size and item count
 
         This method returns a json representation of a default pagination
         metadata structure. It can be overridden to use another structure.
         """
-        page_header = OrderedDict()
-        page_header['total'] = item_count
+        page_metadata = OrderedDict()
+        page_metadata['total'] = item_count
         if item_count == 0:
-            page_header['total_pages'] = 0
+            page_metadata['total_pages'] = 0
         else:
             # First / last page, page count
             page_count = ((item_count - 1) // page_size) + 1
             first_page = 1
             last_page = page_count
-            page_header['total_pages'] = page_count
-            page_header['first_page'] = first_page
-            page_header['last_page'] = last_page
+            page_metadata['total_pages'] = page_count
+            page_metadata['first_page'] = first_page
+            page_metadata['last_page'] = last_page
             # Page, previous / next page
             if page <= last_page:
-                page_header['page'] = page
+                page_metadata['page'] = page
                 if page > first_page:
-                    page_header['previous_page'] = page - 1
+                    page_metadata['previous_page'] = page - 1
                 if page < last_page:
-                    page_header['next_page'] = page + 1
-        header = PaginationHeaderSchema().dumps(page_header)
+                    page_metadata['next_page'] = page + 1
+        metadata = PaginationMetadataSchema().dumps(page_metadata)
         if MARSHMALLOW_VERSION_MAJOR < 3:
-            header = header.data
-        return header
+            metadata = metadata.data
+        return metadata
 
     def _set_pagination_metadata(self, page_params, result, headers):
         """Add pagination metadata to headers
 
         Override this to set pagination data another way
         """
-        page_header = self._make_pagination_header(
+        page_header = self._make_pagination_metadata(
             page_params.page, page_params.page_size,
             page_params.item_count)
         if headers is None:

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -105,14 +105,6 @@ class ResponseMixin:
 
                 return resp
 
-            # Document pagination header if needed
-            if getattr(func, '_paginated', False) is True:
-                doc['responses'][code]['headers'] = {
-                    self.PAGINATION_HEADER_FIELD_NAME: (
-                        self.PAGINATION_HEADER_DOC
-                    )
-                }
-
             # Document default error response
             doc['responses']['default'] = 'DEFAULT_ERROR'
 
@@ -120,6 +112,9 @@ class ResponseMixin:
             # The deepcopy avoids modifying the wrapped function doc
             wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
             wrapper._apidoc['response'] = doc
+            # Indicate which code is the success status code
+            # Helps other decorators documenting success response
+            wrapper._apidoc['success_status_code'] = code
 
             return wrapper
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,7 +9,9 @@ import marshmallow as ma
 from flask.views import MethodView
 
 from flask_smorest import Api, Blueprint, abort, Page
-
+from flask_smorest.pagination import PaginationMetadataSchema
+from flask_smorest.utils import get_appcontext
+from flask_smorest.spec import DEFAULT_RESPONSE_CONTENT_TYPE
 from .mocks import ItemNotFound
 from .utils import build_ref, get_schemas
 
@@ -469,5 +471,117 @@ class TestCustomExamples:
         assert get_schemas(api.spec)['WrapDoc'] == {
             'type': 'object',
             'properties': {'data': build_ref(api.spec, 'schema', 'Doc')}
+        }
+        assert 'Doc' in get_schemas(api.spec)
+
+    @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
+    def test_pagination_in_response_payload(
+            self, app, schemas, openapi_version
+    ):
+        """Demonstrates how to add pagination metadata in response payload"""
+
+        class WrapperBlueprint(Blueprint):
+
+            # Set pagination metadata in app context
+            def _set_pagination_metadata(self, page_params, result, headers):
+                page_meta = self._make_pagination_metadata(
+                    page_params.page, page_params.page_size,
+                    page_params.item_count)
+                get_appcontext()['pagination_metadata'] = page_meta
+                return result, headers
+
+            # Wrap payload data and add pagination metadata if any
+            @staticmethod
+            def _prepare_response_content(data):
+                if data is not None:
+                    ret = {'data': data}
+                    page_meta = get_appcontext().get('pagination_metadata')
+                    if page_meta is not None:
+                        ret['pagination'] = page_meta
+                    return ret
+                return None
+
+            # Document data wrapper
+            # The schema is not used to dump the payload, only to generate doc
+            @staticmethod
+            def _make_doc_response_schema(schema):
+                if schema:
+                    return type(
+                        'Wrap' + schema.__class__.__name__,
+                        (ma.Schema, ),
+                        {'data': ma.fields.Nested(schema)},
+                    )
+                return None
+
+            # Document pagination wrapper
+            # The schema is not used to dump the payload, only to generate doc
+            def _document_pagination_metadata(self, spec, resp_doc):
+                if spec.openapi_version.major < 3:
+                    schema = resp_doc.get('schema')
+                else:
+                    schema = resp_doc.get('content', {}).get(
+                        DEFAULT_RESPONSE_CONTENT_TYPE,
+                        {},
+                    ).get('schema')
+                if schema:
+                    pagin_schema = type(
+                        'Pagination' + schema.__name__,
+                        (schema, ),
+                        {
+                            'pagination': ma.fields.Nested(
+                                PaginationMetadataSchema)
+                        },
+                    )
+                    if spec.openapi_version.major < 3:
+                        resp_doc['schema'] = pagin_schema
+                    else:
+                        resp_doc['content'][DEFAULT_RESPONSE_CONTENT_TYPE][
+                            'schema'] = pagin_schema
+
+        app.config['OPENAPI_VERSION'] = openapi_version
+        api = Api(app)
+        client = app.test_client()
+        blp = WrapperBlueprint('test', __name__, url_prefix='/test')
+
+        @blp.route('/')
+        @blp.response(schemas.DocSchema(many=True))
+        @blp.paginate(Page)
+        def func():
+            return [
+                {'item_id': 1, 'db_field': 42},
+                {'item_id': 2, 'db_field': 69},
+            ]
+
+        api.register_blueprint(blp)
+        spec = api.spec.to_dict()
+
+        # Test data is wrapped and pagination metadata added
+        resp = client.get('/test/')
+        assert resp.json == {
+            'data': [{'field': 42, 'item_id': 1}, {'field': 69, 'item_id': 2}],
+            'pagination': {
+                'page': 1, 'first_page': 1, 'last_page': 1,
+                'total': 2, 'total_pages': 1,
+            }
+        }
+
+        # Test pagination is correctly documented
+        if openapi_version == '3.0.2':
+            content = spec['paths']['/test/']['get']['responses']['200'][
+                'content']['application/json']
+        else:
+            content = spec['paths']['/test/']['get']['responses']['200']
+        assert content['schema'] == build_ref(
+            api.spec, 'schema', 'PaginationWrapDoc')
+        assert get_schemas(api.spec)['PaginationWrapDoc'] == {
+            'type': 'object',
+            'properties': {
+                'data': {
+                    'items': build_ref(api.spec, 'schema', 'Doc'),
+                    'type': 'array',
+                },
+                'pagination': build_ref(
+                    api.spec, 'schema', 'PaginationMetadata'),
+            }
         }
         assert 'Doc' in get_schemas(api.spec)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -167,11 +167,11 @@ class TestPagination:
         api.register_blueprint(blp)
         spec = api.spec.to_dict()
         get = spec['paths']['/test/']['get']
-        assert 'PaginationHeader' in get_schemas(api.spec)
+        assert 'PaginationMetadata' in get_schemas(api.spec)
         assert get['responses']['200']['headers'] == {
             'X-Custom-Pagination-Header': {
                 'description': 'Pagination metadata',
-                'schema': {'$ref': '#/components/schemas/PaginationHeader'},
+                'schema': {'$ref': '#/components/schemas/PaginationMetadata'},
             }
         }
 


### PR DESCRIPTION
This PR adds a test to demonstrate pagination in response payload with response wrapped:

```py
reponse_payload = {
    'data': {...},
    'pagination': {...},

}
```

The PR also includes a few nice refactor commits, some of which were needed for the feature.

`test_pagination_in_response_payload` is introduced in the penultimate commit, then reworked in the last. I'm keeping the two commits for history, but I prefer the last version.