### PR TITLE
Use HTTPStatus phrase, not name, in response description

### DIFF
--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -60,7 +60,7 @@ class ResponseMixin:
         if description is not None:
             resp_doc['description'] = description
         else:
-            resp_doc['description'] = http.HTTPStatus(int(code)).name
+            resp_doc['description'] = http.HTTPStatus(int(code)).phrase
         if example is not None:
             resp_doc['example'] = example
         if examples is not None:

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -555,12 +555,12 @@ class TestBlueprint:
         blp = Blueprint('test', 'test', url_prefix='/test')
 
         @blp.route('/route_1')
-        @blp.response()
+        @blp.response(code=204)
         def func_1():
             pass
 
         @blp.route('/route_2')
-        @blp.response(description='Test')
+        @blp.response(code=204, description='Test')
         def func_2():
             pass
 
@@ -568,11 +568,11 @@ class TestBlueprint:
 
         get_1 = api.spec.to_dict()['paths']['/test/route_1']['get']
         assert (
-            get_1['responses']['200']['description'] ==
-            http.HTTPStatus(200).phrase
+            get_1['responses']['204']['description'] ==
+            http.HTTPStatus(204).phrase
         )
         get_2 = api.spec.to_dict()['paths']['/test/route_2']['get']
-        assert get_2['responses']['200']['description'] == 'Test'
+        assert get_2['responses']['204']['description'] == 'Test'
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
     def test_blueprint_response_example(self, app, openapi_version):


### PR DESCRIPTION
Fixes a mistake made in #137.

The description should be `phrase`, not `name`.

Using 204 in the test because `HTTPStatus(200)` has `'OK'` for both `name` and `phrase`.