### PR TITLE
Add Blueprint.alt_response decorator to document alternative responses

### DIFF
--- a/docs/response.rst
+++ b/docs/response.rst
@@ -52,3 +52,29 @@ If a view function returns a list of objects, the :class:`Schema
         @blp.response(200, PetSchema(many=True))
         def get(self, args):
             return Pet.get()
+
+.. note:: If a view function returns a :class:`werkzeug.BaseResponse`, that
+   response object is returned unchanged: it is not dumped by the schema and
+   the status code is not applied.
+
+.. note:: If a view function returns a tuple containing a status code, this
+   status code is used in place of the one specified as ``response`` parameter.
+   Doing this is generally a bad idea because the response status code won't
+   match the code in the API documentation.
+
+Documenting Alternative Responses
+=================================
+
+The :meth:`Blueprint.response <Blueprint.response>` decorator is meant to
+generate and document the response corresponding to the "normal" flow of the
+function. There can be alternative flows, if the function raises an exception,
+which results in a ``HTTPException``, or if it returns a ``Response`` object
+which is returned as is.
+
+Those alternative responses can be documented using the
+:meth:`Blueprint.response <Blueprint.alt_response>` decorator. Its signature is
+the same as ``response`` but its parameters are only used to document the
+response.
+
+A view function may only be decorated once with ``response`` but can be
+decorated multiple times with nested ``alt_response``.

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -8,7 +8,7 @@ from werkzeug.wrappers import BaseResponse
 from flask import jsonify
 
 from .utils import (
-    deepupdate, get_appcontext, prepare_response,
+    deepupdate, remove_none, get_appcontext, prepare_response,
     unpack_tuple_response, set_status_and_headers_in_response
 )
 from .spec import DEFAULT_RESPONSE_CONTENT_TYPE
@@ -55,17 +55,13 @@ class ResponseMixin:
         doc_schema = self._make_doc_response_schema(schema)
         if description is None:
             description = http.HTTPStatus(int(code)).phrase
-        resp_doc = {
-            k: v
-            for k, v in {
-                "schema": doc_schema,
-                "description": description,
-                "example": example,
-                "examples": examples,
-                "headers": headers,
-            }.items()
-            if v is not None
-        }
+        resp_doc = remove_none({
+            "schema": doc_schema,
+            "description": description,
+            "example": example,
+            "examples": examples,
+            "headers": headers,
+        })
 
         def decorator(func):
 
@@ -143,17 +139,13 @@ class ResponseMixin:
             doc_schema = self._make_doc_response_schema(schema)
             if description is None:
                 description = http.HTTPStatus(int(code)).phrase
-            resp_doc = {
-                k: v
-                for k, v in {
-                    "schema": doc_schema,
-                    "description": description,
-                    "example": example,
-                    "examples": examples,
-                    "headers": headers,
-                }.items()
-                if v is not None
-            }
+            resp_doc = remove_none({
+                "schema": doc_schema,
+                "description": description,
+                "example": example,
+                "examples": examples,
+                "headers": headers,
+            })
 
         def decorator(func):
 

--- a/flask_smorest/utils.py
+++ b/flask_smorest/utils.py
@@ -23,6 +23,11 @@ def deepupdate(original, update):
     return original
 
 
+def remove_none(mapping):
+    """Remove None values in a dict"""
+    return {k: v for k, v in mapping.items() if v is not None}
+
+
 # XXX: Does this belong here?
 def get_appcontext():
     """Return extension section from top of appcontext stack"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,11 @@ def schemas():
         arg1 = ma.fields.String()
         arg2 = ma.fields.Integer()
 
+    class ClientErrorSchema(ma.Schema):
+        error_id = ma.fields.Str()
+        text = ma.fields.Str()
+
     return namedtuple(
-        'Model', ('DocSchema', 'DocEtagSchema', 'QueryArgsSchema'))(
-            DocSchema, DocEtagSchema, QueryArgsSchema)
+        'Model',
+        ('DocSchema', 'DocEtagSchema', 'QueryArgsSchema', 'ClientErrorSchema')
+    )(DocSchema, DocEtagSchema, QueryArgsSchema, ClientErrorSchema)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-from flask_smorest.utils import deepupdate, load_info_from_docstring
+from flask_smorest.utils import (
+    deepupdate, remove_none, load_info_from_docstring
+)
 
 
 class TestUtils:
@@ -33,6 +35,11 @@ class TestUtils:
             },
             'age': {'category': 'puppy'},
         }
+
+    def test_remove_none(self):
+        mapping = {"a": 0, "b": "1", "c": "", "d": False, "e": None}
+        result = remove_none(mapping)
+        assert result == {"a": 0, "b": "1", "c": "", "d": False}
 
     def test_load_info_from_docstring(self):
         assert (load_info_from_docstring(None)) == {}


### PR DESCRIPTION
Closes #44.

Allows to document error with a schema like in response or with a reference.

Needs a bit of factorization.

Makes me want to change response signature to make code the first positional argument, for consistency. There is no real reason to use 200 as a default. (#193)