### PR TITLE
Added error documenting to Blueprint.response

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,10 @@ def schemas():
         arg1 = ma.fields.String()
         arg2 = ma.fields.Integer()
 
+    class ClientErrorSchema(ma.Schema):
+        error_id = ma.fields.Str()
+        text = ma.fields.Str()
+
     return namedtuple(
-        'Model', ('DocSchema', 'DocEtagSchema', 'QueryArgsSchema'))(
-            DocSchema, DocEtagSchema, QueryArgsSchema)
+        'Model', ('DocSchema', 'DocEtagSchema', 'QueryArgsSchema', 'ClientErrorSchema'))(
+            DocSchema, DocEtagSchema, QueryArgsSchema, ClientErrorSchema)

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -652,6 +652,105 @@ class TestBlueprint:
             api.spec, 'response', 'DEFAULT_ERROR'
         )
 
+    @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
+    def test_blueprint_error_schema(self, app, openapi_version, schemas):
+        """Check error schema is correctly documented"""
+        app.config['OPENAPI_VERSION'] = openapi_version
+        api = Api(app)
+        blp = Blueprint('test', 'test', url_prefix='/test')
+
+        example = {'error_id': 'E1', 'text': 'client error'}
+        examples = {
+            'example 1': {'error_id': 'E1', 'text': 'client error 1'},
+            'example 2': {'error_id': 'E2', 'text': 'client error 2'},
+        }
+
+        @blp.route('/')
+        @blp.response(schemas.ClientErrorSchema, code=400)
+        def func():
+            pass
+
+        @blp.route('/description')
+        @blp.response(schemas.ClientErrorSchema, code=400, description='Client error')
+        def func_with_description():
+            pass
+
+        @blp.route('/example')
+        @blp.response(schemas.ClientErrorSchema, code=400, example=example)
+        def func_with_example():
+            pass
+
+        if openapi_version == '3.0.2':
+            @blp.route('/examples')
+            @blp.response(schemas.ClientErrorSchema, code=400, examples=examples)
+            def func_with_examples():
+                pass
+
+        @blp.route('/multiple')
+        @blp.response(schemas.ClientErrorSchema, code=400)
+        @blp.response(schemas.ClientErrorSchema, code=404)
+        def func_with_multiple_errors():
+            pass
+
+        api.register_blueprint(blp)
+
+        paths = api.spec.to_dict()['paths']
+
+        schema_ref = build_ref(api.spec, 'schema', 'ClientError')
+
+        response = paths['/test/']['get']['responses']['400']
+        if openapi_version == '2.0':
+            assert response['schema'] == schema_ref
+        else:
+            assert (
+                    response['content']['application/json']['schema'] ==
+                    schema_ref
+            )
+        assert response['description'] == http.HTTPStatus(400).phrase
+
+        response = paths['/test/description']['get']['responses']['400']
+        assert response['description'] == 'Client error'
+
+        response = paths['/test/example']['get']['responses']['400']
+        if openapi_version == '2.0':
+            assert response['examples']['application/json'] == example
+        else:
+            assert (
+                    response['content']['application/json']['example'] == example
+            )
+
+        if openapi_version == '3.0.2':
+            response = paths['/test/examples']['get']['responses']['400']
+            assert (
+                    response['content']['application/json']['examples'] == examples
+            )
+
+        responses = paths['/test/multiple']['get']['responses']
+        assert '400' in responses and '404' in responses
+
+    @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
+    def test_blueprint_error_ref(self, app, openapi_version):
+        """Check error passed as reference"""
+        app.config['OPENAPI_VERSION'] = openapi_version
+        api = Api(app)
+        api.spec.components.response('ClientErrorResponse')
+
+        blp = Blueprint('test', 'test', url_prefix='/test')
+
+        @blp.route('/')
+        @blp.response("ClientErrorResponse", code=400)
+        def func():
+            pass
+
+        api.register_blueprint(blp)
+
+        paths = api.spec.to_dict()['paths']
+
+        response_ref = build_ref(api.spec, 'response', 'ClientErrorResponse')
+
+        response = paths['/test/']['get']['responses']['400']
+        assert response == response_ref
+
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
     def test_blueprint_pagination(self, app, schemas, openapi_version):
         app.config['OPENAPI_VERSION'] = openapi_version


### PR DESCRIPTION
Closes #44 

This is an alternative solution to #159 (of which I used a lot of code was used). This also fixes some of the positioning issues of [referenced here](https://github.com/marshmallow-code/flask-smorest/issues/36#issuecomment-461818791). I would love to hear whether people prefer this method or the method in #159.

Also, as multiple responses decorators can be used to document multiple errors, they could also be used to document multiple responses (with different codes) if needed. For this, it might be useful to check whether the status code specified by the response decorator matches the status code returned by the API method. I didn't include this as this might break some stuff. 