### PR TITLE
feat: Allow specify API title from config

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -31,6 +31,16 @@ specified as Flask application parameters:
    The OpenAPI version must be passed either as application parameter or at
    :class:`Api <Api>` initialization in ``spec_kwargs`` parameters.
 
+Specify Title
+-------------
+
+.. describe:: API_TITLE
+
+   Title of the API. Human friendly string describing the API.
+
+   Default: _Flask App name_
+
+
 Add Documentation Information to Resources
 ------------------------------------------
 
@@ -263,7 +273,7 @@ page using the JS script from the script URL.
 .. describe:: OPENAPI_REDOC_URL
 
    URL to the ReDoc script.
-   
+
    Examples:
        * https://rebilly.github.io/ReDoc/releases/v1.x.x/redoc.min.js
        * https://rebilly.github.io/ReDoc/releases/v1.22.3/redoc.min.js

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -103,12 +103,12 @@ class DocBlueprintMixin:
     def _openapi_redoc(self):
         """Expose OpenAPI spec with ReDoc"""
         return flask.render_template(
-            'redoc.html', title=self._app.name, redoc_url=self._redoc_url)
+            'redoc.html', title=self.spec.title, redoc_url=self._redoc_url)
 
     def _openapi_swagger_ui(self):
         """Expose OpenAPI spec with Swagger UI"""
         return flask.render_template(
-            'swagger_ui.html', title=self._app.name,
+            'swagger_ui.html', title=self.spec.title,
             swagger_ui_url=self._swagger_ui_url,
             swagger_ui_supported_submit_methods=(
                 self._swagger_ui_supported_submit_methods)
@@ -148,7 +148,7 @@ class APISpecMixin(DocBlueprintMixin):
 
         # Instantiate spec
         self.spec = apispec.APISpec(
-            self._app.name,
+            self._app.config.get('API_TITLE', self._app.name),
             self._app.config.get('API_VERSION', '1'),
             openapi_version=openapi_version,
             plugins=plugins,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -204,12 +204,13 @@ class TestApi:
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
     def test_api_gets_apispec_parameters_from_app(self, app, openapi_version):
+        app.config['API_TITLE'] = 'My API Title'
         app.config['API_VERSION'] = 'v42'
         app.config['OPENAPI_VERSION'] = openapi_version
         api = Api(app)
         spec = api.spec.to_dict()
 
-        assert spec['info'] == {'title': 'API Test', 'version': 'v42'}
+        assert spec['info'] == {'title': 'My API Title', 'version': 'v42'}
         if openapi_version == '2.0':
             assert spec['swagger'] == '2.0'
         else:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -60,6 +60,8 @@ class TestAPISpecServeDocs:
         """Test default values and leading/trailing slashes issues"""
 
         class NewAppConfig(AppConfig):
+            API_TITLE = 'My API title'
+
             if prefix is not None:
                 OPENAPI_URL_PREFIX = prefix
             if json_path is not None:
@@ -73,6 +75,7 @@ class TestAPISpecServeDocs:
             if swagger_ui_url is not None:
                 OPENAPI_SWAGGER_UI_URL = swagger_ui_url
 
+        title_tag = '<title>My API title</title>'
         app.config.from_object(NewAppConfig)
         Api(app)
         client = app.test_client()
@@ -85,7 +88,7 @@ class TestAPISpecServeDocs:
             assert response_swagger_ui.status_code == 404
         else:
             assert response_json_docs.json['info'] == {
-                'version': '1', 'title': 'API Test'}
+                'version': '1', 'title': 'My API title'}
             if (
                     app.config.get('OPENAPI_REDOC_PATH') is None or
                     app.config.get('OPENAPI_REDOC_URL') is None
@@ -95,6 +98,7 @@ class TestAPISpecServeDocs:
                 assert response_redoc.status_code == 200
                 assert (response_redoc.headers['Content-Type'] ==
                         'text/html; charset=utf-8')
+                assert title_tag in response_redoc.get_data(True)
             if (
                     app.config.get('OPENAPI_SWAGGER_UI_PATH') is None or
                     app.config.get('OPENAPI_SWAGGER_UI_URL') is None
@@ -104,6 +108,7 @@ class TestAPISpecServeDocs:
                 assert response_swagger_ui.status_code == 200
                 assert (response_swagger_ui.headers['Content-Type'] ==
                         'text/html; charset=utf-8')
+                assert title_tag in response_swagger_ui.get_data(True)
 
     @pytest.mark.parametrize('prefix', ('', '/'))
     @pytest.mark.parametrize('path', ('', '/'))


### PR DESCRIPTION
By default, API title still using Flask app name, but it is now possible to pass custom string via `API_TITLE` config var.

Also ensure using spec title within `<title>` tag at Swagger UI / Redoc pages.

Issue: #164