### PR TITLE
Fix version and title parameters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors (chronological)
 - Douglas Thor `@dougthor42 <https://github.com/dougthor42>`_
 - Steven Loria `@sloria <https://github.com/sloria>`_
 - Jón Bjarnason `@nonnib <https://github.com/nonnib>`_
+- Igor Davydenko `@playpauseandstop <https://github.com/playpauseandstop>`_

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -10,35 +10,37 @@ known as Swagger) for the API.
 That documentation can be made accessible as a JSON file, along with a nice web
 interface such as `ReDoc`_ or `Swagger UI`_.
 
-Specify Versions
-----------------
+API parameters
+--------------
 
-The version of the API and the version of the OpenAPI specification can be
-specified as Flask application parameters:
+The following API and OpenAPI parameters must be passed either as application
+configuration parameter or at initialization. If both are used, the application
+configuration parameter takes precedence.
+
+.. describe:: API_TITLE
+
+   Title of the API. Human friendly string describing the API.
+
+   API title must be passed either as application parameter or as `title`
+   at :class:`Api <Api>` initialization in ``spec_kwargs`` parameters.
 
 .. describe:: API_VERSION
 
    Version of the API. It is copied verbatim in the documentation. It should be
-   a string, even it the version is a number.
+   a string, even if the version is a number.
 
-   Default: ``'1'``
+   API version must be passed either as application parameter or as `version`
+   at :class:`Api <Api>` initialization in ``spec_kwargs`` parameters.
 
 .. describe:: OPENAPI_VERSION
 
    Version of the OpenAPI standard used to describe the API. It should be
    provided as a string.
 
-   The OpenAPI version must be passed either as application parameter or at
-   :class:`Api <Api>` initialization in ``spec_kwargs`` parameters.
+   OpenAPI version must be passed either as application parameter or as
+   `openapi_version` at :class:`Api <Api>` initialization in ``spec_kwargs``
+   parameters.
 
-Specify Title
--------------
-
-.. describe:: API_TITLE
-
-   Title of the API. Human friendly string describing the API.
-
-   Default: _Flask App name_
 
 
 Add Documentation Information to Resources

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -31,6 +31,16 @@ specified as Flask application parameters:
    The OpenAPI version must be passed either as application parameter or at
    :class:`Api <Api>` initialization in ``spec_kwargs`` parameters.
 
+Specify Title
+-------------
+
+.. describe:: API_TITLE
+
+   Title of the API. Human friendly string describing the API.
+
+   Default: _Flask App name_
+
+
 Add Documentation Information to Resources
 ------------------------------------------
 
@@ -263,7 +273,7 @@ page using the JS script from the script URL.
 .. describe:: OPENAPI_REDOC_URL
 
    URL to the ReDoc script.
-   
+
    Examples:
        * https://rebilly.github.io/ReDoc/releases/v1.x.x/redoc.min.js
        * https://rebilly.github.io/ReDoc/releases/v1.22.3/redoc.min.js

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,7 +39,9 @@ First instantiate an :class:`Api <Api>` with a :class:`Flask <flask.Flask>` appl
 
     from .model import Pet
 
-    app = Flask('My API')
+    app = Flask(__name__)
+    app.config['TITLE'] = 'My API'
+    app.config['API_VERSION'] = 'v1'
     app.config['OPENAPI_VERSION'] = '3.0.2'
     api = Api(app)
 

--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -26,13 +26,14 @@ class Api(APISpecMixin, ErrorHandlerMixin):
     :param apispec.BasePlugin marshmallow_plugin: Marshmallow plugin
     :param list|tuple extra_plugins: List of additional ``BasePlugin``
         instances
+    :param str title: API title. Can also be passed as
+        application parameter `API_TITLE`.
+    :param str version: API version. Can also be passed as
+        application parameter `API_VERSION`.
     :param str openapi_version: OpenAPI version. Can also be passed as
         application parameter `OPENAPI_VERSION`.
 
     This allows the user to override default Flask and marshmallow plugins.
-
-    `title` and `version` APISpec parameters can't be passed here, they are set
-    according to the app configuration.
 
     For more flexibility, additional spec kwargs can also be passed as app
     parameter `API_SPEC_OPTIONS`.

--- a/flask_smorest/exceptions.py
+++ b/flask_smorest/exceptions.py
@@ -7,8 +7,8 @@ class FlaskSmorestError(Exception):
     """Generic flask-smorest exception"""
 
 
-class OpenAPIVersionNotSpecified(FlaskSmorestError):
-    """OpenAPI version was not specified"""
+class MissingAPIParameterError(FlaskSmorestError):
+    """Missing API parameter"""
 
 
 class CheckEtagNotCalledError(FlaskSmorestError):

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -103,12 +103,12 @@ class DocBlueprintMixin:
     def _openapi_redoc(self):
         """Expose OpenAPI spec with ReDoc"""
         return flask.render_template(
-            'redoc.html', title=self._app.name, redoc_url=self._redoc_url)
+            'redoc.html', title=self.spec.title, redoc_url=self._redoc_url)
 
     def _openapi_swagger_ui(self):
         """Expose OpenAPI spec with Swagger UI"""
         return flask.render_template(
-            'swagger_ui.html', title=self._app.name,
+            'swagger_ui.html', title=self.spec.title,
             swagger_ui_url=self._swagger_ui_url,
             swagger_ui_supported_submit_methods=(
                 self._swagger_ui_supported_submit_methods)
@@ -148,7 +148,7 @@ class APISpecMixin(DocBlueprintMixin):
 
         # Instantiate spec
         self.spec = apispec.APISpec(
-            self._app.name,
+            self._app.config.get('API_TITLE', self._app.name),
             self._app.config.get('API_VERSION', '1'),
             openapi_version=openapi_version,
             plugins=plugins,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ class AppConfig:
 
     Overload this to add config parameters
     """
+    API_TITLE = 'API Test'
+    API_VERSION = '1'
     OPENAPI_VERSION = '3.0.2'
 
 
@@ -29,7 +31,7 @@ def collection(request):
 
 @pytest.fixture(params=[AppConfig])
 def app(request):
-    _app = Flask('API Test')
+    _app = Flask(__name__)
     _app.config.from_object(request.param)
     return _app
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -204,12 +204,13 @@ class TestApi:
 
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
     def test_api_gets_apispec_parameters_from_app(self, app, openapi_version):
+        app.config['API_TITLE'] = 'My API Title'
         app.config['API_VERSION'] = 'v42'
         app.config['OPENAPI_VERSION'] = openapi_version
         api = Api(app)
         spec = api.spec.to_dict()
 
-        assert spec['info'] == {'title': 'API Test', 'version': 'v42'}
+        assert spec['info'] == {'title': 'My API Title', 'version': 'v42'}
         if openapi_version == '2.0':
             assert spec['swagger'] == '2.0'
         else:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -60,6 +60,8 @@ class TestAPISpecServeDocs:
         """Test default values and leading/trailing slashes issues"""
 
         class NewAppConfig(AppConfig):
+            API_TITLE = 'My API title'
+
             if prefix is not None:
                 OPENAPI_URL_PREFIX = prefix
             if json_path is not None:
@@ -73,6 +75,7 @@ class TestAPISpecServeDocs:
             if swagger_ui_url is not None:
                 OPENAPI_SWAGGER_UI_URL = swagger_ui_url
 
+        title_tag = '<title>My API title</title>'
         app.config.from_object(NewAppConfig)
         Api(app)
         client = app.test_client()
@@ -85,7 +88,7 @@ class TestAPISpecServeDocs:
             assert response_swagger_ui.status_code == 404
         else:
             assert response_json_docs.json['info'] == {
-                'version': '1', 'title': 'API Test'}
+                'version': '1', 'title': 'My API title'}
             if (
                     app.config.get('OPENAPI_REDOC_PATH') is None or
                     app.config.get('OPENAPI_REDOC_URL') is None
@@ -95,6 +98,7 @@ class TestAPISpecServeDocs:
                 assert response_redoc.status_code == 200
                 assert (response_redoc.headers['Content-Type'] ==
                         'text/html; charset=utf-8')
+                assert title_tag in response_redoc.get_data(True)
             if (
                     app.config.get('OPENAPI_SWAGGER_UI_PATH') is None or
                     app.config.get('OPENAPI_SWAGGER_UI_URL') is None
@@ -104,6 +108,7 @@ class TestAPISpecServeDocs:
                 assert response_swagger_ui.status_code == 200
                 assert (response_swagger_ui.headers['Content-Type'] ==
                         'text/html; charset=utf-8')
+                assert title_tag in response_swagger_ui.get_data(True)
 
     @pytest.mark.parametrize('prefix', ('', '/'))
     @pytest.mark.parametrize('path', ('', '/'))

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -60,8 +60,6 @@ class TestAPISpecServeDocs:
         """Test default values and leading/trailing slashes issues"""
 
         class NewAppConfig(AppConfig):
-            API_TITLE = 'My API title'
-
             if prefix is not None:
                 OPENAPI_URL_PREFIX = prefix
             if json_path is not None:
@@ -75,7 +73,7 @@ class TestAPISpecServeDocs:
             if swagger_ui_url is not None:
                 OPENAPI_SWAGGER_UI_URL = swagger_ui_url
 
-        title_tag = '<title>My API title</title>'
+        title_tag = '<title>API Test</title>'
         app.config.from_object(NewAppConfig)
         Api(app)
         client = app.test_client()
@@ -88,7 +86,7 @@ class TestAPISpecServeDocs:
             assert response_swagger_ui.status_code == 404
         else:
             assert response_json_docs.json['info'] == {
-                'version': '1', 'title': 'My API title'}
+                'version': '1', 'title': 'API Test'}
             if (
                     app.config.get('OPENAPI_REDOC_PATH') is None or
                     app.config.get('OPENAPI_REDOC_URL') is None


### PR DESCRIPTION
Closes #164.
Built upon and replaces #165.

I went further with #165, as discussed in comments in #164.

Bascially, title can not be derived from app name anymore as this was wrong. And version does not default to '1' because there's no real reason to do so. Both are now required and can be passed at init or as app config params.

Also `OpenAPIVersionNotSpecified` is renamed to `MissingAPIParameterError` and used for other missing parameters.

