### PR TITLE
Adding support for OPENAPI_SWAGGER_UI_CONFIG

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Contributors (chronological)
 - Steven Loria `@sloria <https://github.com/sloria>`_
 - Jón Bjarnason `@nonnib <https://github.com/nonnib>`_
 - Igor Davydenko `@playpauseandstop <https://github.com/playpauseandstop>`_
+- Joshua Harrison `@joshua-harrison-2011 <https://github.com/joshua-harrison-2011>`_

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -303,14 +303,15 @@ page using the JS script from the script URL.
 
    Default: ``None``
 
-.. describe:: OPENAPI_SWAGGER_UI_SUPPORTED_SUBMIT_METHODS
+.. describe:: OPENAPI_SWAGGER_UI_CONFIG
 
-   List of methods for which the '*Try it out!*' feature is enabled. Should be a
-   list of lowercase HTTP methods.
+   Dictionary representing Swagger UI configuration options.  See `Swagger UI Configuration`_ for available options.
+   All JSON serializable options are supported.
 
-   Passing an empty list disables the feature globally.
+   Examples:
+      * ``{'deepLinking': True, 'supportedSubmitMethods': ['get', 'post']}``
 
-   Default: ``['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']``
+   Default: ``{}``
 
 Here's an example application configuration using both ReDoc and Swagger UI:
 
@@ -327,6 +328,7 @@ Here's an example application configuration using both ReDoc and Swagger UI:
 
 .. _ReDoc: https://github.com/Rebilly/ReDoc
 .. _Swagger UI: https://swagger.io/tools/swagger-ui/
+.. _Swagger UI Configuration: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
 
 Write OpenAPI Documentation File
 --------------------------------

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -72,21 +72,12 @@ class DocBlueprintMixin:
 
         The Swagger UI scripts base URL should be specified as
         OPENAPI_SWAGGER_UI_URL.
-
-        OPENAPI_SWAGGER_UI_SUPPORTED_SUBMIT_METHODS specifes the methods for
-        which the 'Try it out!' feature is enabled.
         """
         swagger_ui_path = self._app.config.get('OPENAPI_SWAGGER_UI_PATH')
         if swagger_ui_path is not None:
             swagger_ui_url = self._app.config.get('OPENAPI_SWAGGER_UI_URL')
             if swagger_ui_url is not None:
                 self._swagger_ui_url = swagger_ui_url
-                self._swagger_ui_supported_submit_methods = (
-                    self._app.config.get(
-                        'OPENAPI_SWAGGER_UI_SUPPORTED_SUBMIT_METHODS',
-                        ['get', 'put', 'post', 'delete', 'options',
-                         'head', 'patch', 'trace'])
-                )
                 blueprint.add_url_rule(
                     _add_leading_slash(swagger_ui_path),
                     endpoint='openapi_swagger_ui',
@@ -110,8 +101,7 @@ class DocBlueprintMixin:
         return flask.render_template(
             'swagger_ui.html', title=self.spec.title,
             swagger_ui_url=self._swagger_ui_url,
-            swagger_ui_supported_submit_methods=(
-                self._swagger_ui_supported_submit_methods)
+            swagger_ui_config=self._app.config.get('OPENAPI_SWAGGER_UI_CONFIG', {})
         )
 
 

--- a/flask_smorest/spec/templates/swagger_ui.html
+++ b/flask_smorest/spec/templates/swagger_ui.html
@@ -13,15 +13,17 @@
    <script src="{{swagger_ui_url}}swagger-ui-standalone-preset.js"></script>
    <script src="{{swagger_ui_url}}swagger-ui-bundle.js"></script>
    <script>
+
+     config = {
+       url: "{{ url_for('api-docs.openapi_json') }}",
+       dom_id: '#swagger-ui-container'
+     }
+
+     var override_config = {{ swagger_ui_config | tojson }};
+     for (var attrname in override_config) { config[attrname] = override_config[attrname]; }
+
      window.onload = function() {
-       const ui = SwaggerUIBundle({
-         url: "{{ url_for('api-docs.openapi_json') }}",
-         dom_id: '#swagger-ui-container',
-         deepLinking: true,
-         layout: "BaseLayout",
-         supportedSubmitMethods: [{% for meth in swagger_ui_supported_submit_methods %}"{{meth.lower()}}",{% endfor %}],
-       })
-       window.ui = ui
+       window.ui = SwaggerUIBundle(config)
      }
    </script>
 


### PR DESCRIPTION
This is patterned on https://github.com/sveint/flask-swagger-ui/blob/master/flask_swagger_ui/templates/index.template.html and is intended to address https://github.com/marshmallow-code/flask-smorest/issues/69.  I think it could also cover the use case in https://github.com/marshmallow-code/flask-smorest/pull/67.