### PR TITLE
Minor quickstart doc fix

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -40,7 +40,7 @@ First instantiate an :class:`Api <Api>` with a :class:`Flask <flask.Flask>` appl
     from .model import Pet
 
     app = Flask(__name__)
-    app.config['TITLE'] = 'My API'
+    app.config['API_TITLE'] = 'My API'
     app.config['API_VERSION'] = 'v1'
     app.config['OPENAPI_VERSION'] = '3.0.2'
     api = Api(app)


### PR DESCRIPTION
New API parameter API_TITLE is not correctly named in quickstart doc.