### PR TITLE
Restore set status and headers on response object

### DIFF
--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -80,6 +80,8 @@ class ResponseMixin:
 
                 # If return value is a werkzeug BaseResponse, return it
                 if isinstance(result_raw, BaseResponse):
+                    set_status_and_headers_in_response(
+                        result_raw, status, headers)
                     return result_raw
 
                 # Dump result with schema if specified

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -8,6 +8,7 @@ import pytest
 
 import marshmallow as ma
 
+import flask
 from flask.views import MethodView
 
 from flask_smorest import Api, Blueprint, Page
@@ -1118,14 +1119,14 @@ class TestBlueprint:
         # Schema is ignored when response object is returned
         @blp.response(schemas.DocSchema, code=200)
         def func_response():
-            return {}, 201, {'X-header': 'test'}
+            return flask.jsonify({"test": "test"}), 201, {'X-header': 'test'}
 
         api.register_blueprint(blp)
 
         response = client.get('/test/response')
         assert response.status_code == 201
         assert response.status == '201 CREATED'
-        assert response.json == {}
+        assert response.json == {"test": "test"}
         assert response.headers['X-header'] == 'test'
 
     @pytest.mark.parametrize('decorate', (True, False))


### PR DESCRIPTION
Fixes #176.

Reverts 2a793ad.

2a793ad removed a call that I thought useless. No test case was broken because the test that was meant to test that had been screwed in 08612b801a344bedfb1536f42c088d57bc5e4fcd.