### PR TITLE
Don't document int format as int32 and float format as float

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -163,7 +163,7 @@ Documentation components can be passed by accessing the internal apispec
     api.spec.components.parameter(
       'Pet name',
       'query',
-      {'description': 'Item ID', 'format': 'int32', 'required': True}
+      {'description': 'Item ID', 'required': True}
    )
 
 Register Custom Fields
@@ -180,11 +180,11 @@ or by specifying a parent field class, using :meth:`Api.register_field`:
     # Map to ('string', 'ObjectId') passing type and format
     api.register_field(ObjectId, 'string', 'ObjectId')
 
-    # Map to ('string') passing type
+    # Map to ('string', ) passing type
     api.register_field(CustomString, 'string', None)
 
-    # Map to ('integer, 'int32') passing a code marshmallow field
-    api.register_field(CustomInteger, ma.fields.Integer)
+    # Map to ('string, 'date-time') passing a marshmallow Field
+    api.register_field(CustomDateTime, ma.fields.DateTime)
 
 Register Custom Path Parameter Converters
 -----------------------------------------

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -222,11 +222,11 @@ class APISpecMixin(DocBlueprintMixin):
             # Map to ('string', 'ObjectId') passing type and format
             api.register_field(ObjectId, 'string', 'ObjectId')
 
-            # Map to ('string') passing type
+            # Map to ('string', ) passing type
             api.register_field(CustomString, 'string', None)
 
-            # Map to ('integer, 'int32') passing a code marshmallow field
-            api.register_field(CustomInteger, ma.fields.Integer)
+            # Map to ('string, 'date-time') passing a marshmallow Field
+            api.register_field(CustomDateTime, ma.fields.DateTime)
 
         Should be called before registering schemas with
         :meth:`schema <Api.schema>`.

--- a/flask_smorest/spec/plugins.py
+++ b/flask_smorest/spec/plugins.py
@@ -17,8 +17,8 @@ RE_URL = re.compile(r'<(?:[^:<>]+:)?([^<>]+)>')
 # From flask-apispec
 DEFAULT_CONVERTER_MAPPING = {
     werkzeug.routing.UnicodeConverter: ('string', None),
-    werkzeug.routing.IntegerConverter: ('integer', 'int32'),
-    werkzeug.routing.FloatConverter: ('number', 'float'),
+    werkzeug.routing.IntegerConverter: ('integer', None),
+    werkzeug.routing.FloatConverter: ('number', None),
     werkzeug.routing.UUIDConverter: ('string', 'uuid'),
 }
 DEFAULT_TYPE = ('string', None)

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
         'flask>=1.1.0',
         'marshmallow>=3.0.0',
         'webargs>=6.0.0',
-        'apispec>=3.0.0',
+        'apispec>=4.0.0',
     ],
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -121,7 +121,7 @@ class TestApi:
             if mapping[1] is not None:
                 properties['field']['format'] = mapping[1]
         else:
-            properties = {'field': {'type': 'integer', 'format': 'int32'}}
+            properties = {'field': {'type': 'integer'}}
 
         assert get_schemas(api.spec)['Document'] == {
             'properties': properties, 'type': 'object'}

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -415,24 +415,12 @@ class TestBlueprint:
         spec = api.spec.to_dict()
         params = spec['paths']['/test/{item_id}']['parameters']
         assert len(params) == 2
+        assert params[0] == build_ref(api.spec, 'parameter', 'TestParameter')
+        assert params[1]['description'] == 'Item ID'
         if openapi_version == '2.0':
-            assert params == [
-                build_ref(api.spec, 'parameter', 'TestParameter'),
-                {
-                    'name': 'item_id', 'in': 'path', 'required': True,
-                    'description': 'Item ID',
-                    'format': 'int32', 'type': 'integer'
-                },
-            ]
+            assert params[1]['type'] == 'integer'
         else:
-            assert params == [
-                build_ref(api.spec, 'parameter', 'TestParameter'),
-                {
-                    'name': 'item_id', 'in': 'path', 'required': True,
-                    'description': 'Item ID',
-                    'schema': {'format': 'int32', 'type': 'integer'}
-                },
-            ]
+            assert params[1]['schema']['type'] == 'integer'
 
     @pytest.mark.parametrize('as_method_view', (True, False))
     def test_blueprint_route_path_parameter_default(self, app, as_method_view):


### PR DESCRIPTION
Rationale explained in marshmallow-code/apispec#595.

Replaces #183.

Bumping apispec to 4.0.0 for consistency (and to ensure tests pass).