### PR TITLE
Drop marshmallow 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,14 @@ jobs:
   include:
 
     - { python: '3.8', env: TOXENV=lint }
-    - { python: '3.6', env: TOXENV=py36-ma2 }
-    - { python: '3.6', env: TOXENV=py36-ma3 }
-    - { python: '3.7', env: TOXENV=py37-ma3 }
-    - { python: '3.8', env: TOXENV=py38-ma2 }
-    - { python: '3.8', env: TOXENV=py38-ma3 }
+    - { python: '3.6', env: TOXENV=py36 }
+    - { python: '3.7', env: TOXENV=py37 }
+    - { python: '3.8', env: TOXENV=py38 }
 
     - stage: PyPI Release
       if: tag IS present
       python: '3.8'
-      env: TOXENV=py38-ma3
+      env: TOXENV=py38
       install: skip
       script: echo "Releasing to PyPI..."
       deploy:

--- a/flask_smorest/compat.py
+++ b/flask_smorest/compat.py
@@ -1,6 +1,0 @@
-"""Stuff needed to support several versions of dependencies."""
-
-import marshmallow
-
-
-MARSHMALLOW_VERSION_MAJOR = int(marshmallow.__version__.split('.')[0])

--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -13,7 +13,6 @@ from .exceptions import (
     CheckEtagNotCalledError,
     PreconditionRequired, PreconditionFailed, NotModified)
 from .utils import deepupdate, get_appcontext
-from .compat import MARSHMALLOW_VERSION_MAJOR
 
 
 def _is_etag_enabled():
@@ -121,8 +120,6 @@ class EtagMixin:
             if isinstance(etag_schema, type):
                 etag_schema = etag_schema()
             raw_data = etag_schema.dump(etag_data)
-            if MARSHMALLOW_VERSION_MAJOR < 3:
-                raw_data = raw_data.data
         if extra_data:
             raw_data = (raw_data, extra_data)
         # flask's json.dumps is needed here

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -21,7 +21,6 @@ import marshmallow as ma
 from webargs.flaskparser import FlaskParser
 
 from .utils import unpack_tuple_response
-from .compat import MARSHMALLOW_VERSION_MAJOR
 
 
 class PaginationParameters:
@@ -59,10 +58,7 @@ def _pagination_parameters_schema_factory(
 
         class Meta:
             ordered = True
-            if MARSHMALLOW_VERSION_MAJOR < 3:
-                strict = True
-            else:
-                unknown = ma.EXCLUDE
+            unknown = ma.EXCLUDE
 
         page = ma.fields.Integer(
             missing=def_page,
@@ -252,10 +248,7 @@ class PaginationMixin:
                     page_metadata['previous_page'] = page - 1
                 if page < last_page:
                     page_metadata['next_page'] = page + 1
-        metadata = PaginationMetadataSchema().dump(page_metadata)
-        if MARSHMALLOW_VERSION_MAJOR < 3:
-            metadata = metadata.data
-        return metadata
+        return PaginationMetadataSchema().dump(page_metadata)
 
     def _set_pagination_metadata(self, page_params, result, headers):
         """Add pagination metadata to headers

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -11,7 +11,6 @@ from .utils import (
     deepupdate, get_appcontext, prepare_response,
     unpack_tuple_response, set_status_and_headers_in_response
 )
-from .compat import MARSHMALLOW_VERSION_MAJOR
 from .spec import DEFAULT_RESPONSE_CONTENT_TYPE
 
 
@@ -89,8 +88,6 @@ class ResponseMixin:
                     result_dump = result_raw
                 else:
                     result_dump = schema.dump(result_raw)
-                    if MARSHMALLOW_VERSION_MAJOR < 3:
-                        result_dump = result_dump.data
 
                 # Store result in appcontext (may be used for ETag computation)
                 appcontext = get_appcontext()

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'werkzeug>=0.15',
         'flask>=1.1.0',
-        'marshmallow>=2.15.2',
+        'marshmallow>=3.0.0',
         'webargs>=6.0.0',
         'apispec>=3.0.0',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,6 @@ import marshmallow as ma
 
 from flask import Flask
 
-from flask_smorest.compat import MARSHMALLOW_VERSION_MAJOR
-
 from .mocks import DatabaseMock
 
 
@@ -65,25 +63,16 @@ class CounterSchema(ma.Schema):
 def schemas():
 
     class DocSchema(CounterSchema):
-        if MARSHMALLOW_VERSION_MAJOR < 3:
-            class Meta:
-                strict = True
         item_id = ma.fields.Int(dump_only=True)
         field = ma.fields.Int(attribute='db_field')
 
     class DocEtagSchema(CounterSchema):
-        if MARSHMALLOW_VERSION_MAJOR < 3:
-            class Meta:
-                strict = True
         field = ma.fields.Int(attribute='db_field')
 
     class QueryArgsSchema(ma.Schema):
         class Meta:
             ordered = True
-            if MARSHMALLOW_VERSION_MAJOR < 3:
-                strict = True
-            else:
-                unknown = ma.EXCLUDE
+            unknown = ma.EXCLUDE
         arg1 = ma.fields.String()
         arg2 = ma.fields.Integer()
 

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -13,7 +13,6 @@ from flask.views import MethodView
 
 from flask_smorest import Api, Blueprint, Page
 from flask_smorest.fields import Upload
-from flask_smorest.compat import MARSHMALLOW_VERSION_MAJOR
 
 
 from .utils import build_ref
@@ -292,9 +291,6 @@ class TestBlueprint:
         client = app.test_client()
 
         class MultipartSchema(ma.Schema):
-            if MARSHMALLOW_VERSION_MAJOR < 3:
-                class Meta:
-                    strict = True
             file_1 = Upload()
             file_2 = Upload()
 
@@ -795,9 +791,6 @@ class TestBlueprint:
             'content': {'application/json': {'example': {'test': 123}}}}
 
         class ItemSchema(ma.Schema):
-            if MARSHMALLOW_VERSION_MAJOR < 3:
-                class Meta:
-                    strict = True
             test = ma.fields.Int()
 
         @blp.route('/')
@@ -829,9 +822,6 @@ class TestBlueprint:
         doc_desc = {'description': 'Description'}
 
         class ItemSchema(ma.Schema):
-            if MARSHMALLOW_VERSION_MAJOR < 3:
-                class Meta:
-                    strict = True
             test = ma.fields.Int()
 
         @blp.route('/')

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -16,7 +16,6 @@ from flask_smorest.exceptions import (
     CheckEtagNotCalledError,
     NotModified, PreconditionRequired, PreconditionFailed)
 from flask_smorest.utils import get_appcontext
-from flask_smorest.compat import MARSHMALLOW_VERSION_MAJOR
 
 from .mocks import ItemNotFound
 
@@ -179,8 +178,6 @@ class TestEtag:
         etag_schema = schemas.DocEtagSchema
         item = {'item_id': 1, 'db_field': 0}
         item_schema_dump = etag_schema().dump(item)
-        if MARSHMALLOW_VERSION_MAJOR < 3:
-            item_schema_dump = item_schema_dump[0]
         if extra_data is None or extra_data == {}:
             data = item
             data_dump = item_schema_dump

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = lint,{py36,py37,py38}-{ma2,ma3}
+envlist = lint,py36,py37,py38
 
 [testenv]
 deps =
     pytest>=4.0.0
     pytest-cov>=2.6.0
-    ma2: marshmallow>=2.15.0,<3.0.0
-    ma3: marshmallow>=3.0.0
+    marshmallow>=3.0.0
 commands =
     pytest --cov=flask_smorest tests --cov-report term-missing
 


### PR DESCRIPTION
Marshmallow 2 has been end-of-life. It is unsupported by apispec 4 and soon-to-be-released webargs 7.

(The failing test is due to a change in apispec 4 and is fixed in another PR.)