### PR TITLE
Make code argument first positional in @response

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -18,12 +18,12 @@ injected in the view function.
     class Pets(MethodView):
 
         @blp.arguments(PetQueryArgsSchema, location='query')
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         def get(self, args):
             return Pet.get(filters=args)
 
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema, code=201)
+        @blp.response(201, PetSchema)
         def post(self, pet_data):
             return Pet.create(**pet_data)
 
@@ -56,7 +56,7 @@ as keyword arguments instead.
     class Pets(MethodView):
 
         @blp.arguments(PetQueryArgsSchema, location='query', as_kwargs=True)
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         def get(self, **kwargs):
             return Pet.get(filters=**kwargs)
 
@@ -157,7 +157,7 @@ arguments from multiple locations:
 
         @blp.arguments(PetSchema)
         @blp.arguments(QueryArgsSchema, location="query")
-        @blp.response(PetSchema, code=201)
+        @blp.response(201, PetSchema)
         def post(self, pet_data, query_args):
             pet = Pet.create(**pet_data)
             # Use query args
@@ -218,7 +218,7 @@ fields. The files are injected in the view function as a ``dict`` of werkzeug
 
     @blp.route('/', methods=['POST'])
     @blp.arguments(MultipartFileSchema, location='files')
-    @blp.response(code=201)
+    @blp.response(201)
     def func(files):
         base_dir = '/path/to/storage/dir/'
         file_1 = files['file_1']

--- a/docs/etag.rst
+++ b/docs/etag.rst
@@ -41,13 +41,13 @@ though it is the same as the response schema.
     class Pet(MethodView):
 
         @blp.etag
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         def get(self):
             return Pet.get()
 
         @blp.etag
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema)
+        @blp.response(201, PetSchema)
         def post(self, new_data):
             return Pet.create(**new_data)
 
@@ -55,13 +55,13 @@ though it is the same as the response schema.
     class PetById(MethodView):
 
         @blp.etag
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def get(self, pet_id):
             return Pet.get_by_id(pet_id)
 
         @blp.etag
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def put(self, update_data, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action and schema must be provided
@@ -70,7 +70,7 @@ though it is the same as the response schema.
             return pet
 
         @blp.etag
-        @blp.response(code=204)
+        @blp.response(204)
         def delete(self, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action and schema must be provided
@@ -95,13 +95,13 @@ In this case, a specific ETag schema should be provided to
     class Pet(MethodView):
 
         @blp.etag(PetEtagSchema(many=True))
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         def get(self):
             return Pet.get()
 
         @blp.etag(PetEtagSchema)
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema)
+        @blp.response(201, PetSchema)
         def post(self, new_pet):
             return Pet.create(**new_data)
 
@@ -109,13 +109,13 @@ In this case, a specific ETag schema should be provided to
     class PetById(MethodView):
 
         @blp.etag(PetEtagSchema)
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def get(self, pet_id):
             return Pet.get_by_id(pet_id)
 
         @blp.etag(PetEtagSchema)
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def put(self, new_pet, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action and schema must be provided
@@ -124,7 +124,7 @@ In this case, a specific ETag schema should be provided to
             return pet
 
         @blp.etag(PetEtagSchema)
-        @blp.response(code=204)
+        @blp.response(204)
         def delete(self, pet_id):
             pet = self._get_pet(pet_id)
             # Check ETag is a manual action, ETag schema is used
@@ -149,7 +149,7 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
     class Pet(MethodView):
 
         @blp.etag
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         def get(self):
             pets = Pet.get()
             # Compute ETag using arbitrary data
@@ -158,7 +158,7 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
 
         @blp.etag
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema)
+        @blp.response(201, PetSchema)
         def post(self, new_data):
             # Compute ETag using arbitrary data
             blp.set_etag(new_data['update_time'])
@@ -168,7 +168,7 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
     class PetById(MethodView):
 
         @blp.etag
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def get(self, pet_id):
             # Compute ETag using arbitrary data
             blp.set_etag(new_data['update_time'])
@@ -176,7 +176,7 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
 
         @blp.etag
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def put(self, update_data, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action
@@ -187,7 +187,7 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
             return pet
 
         @blp.etag
-        @blp.response(code=204)
+        @blp.response(204)
         def delete(self, pet_id):
             pet = Pet.get_by_id(pet_id)
             # Check ETag is a manual action

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -32,7 +32,7 @@ as ``item_count`` attribute of the `PaginationParameters` object.
     @blp.route('/')
     class Pets(MethodView):
 
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         @blp.paginate()
         def get(self, pagination_parameters):
             pagination_parameters.item_count = Pet.size
@@ -82,7 +82,7 @@ Mongoengine's :class:`QuerySet <mongoengine.queryset.QuerySet>`,...
     @blp.route('/')
     class Pets(MethodView):
 
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         @blp.paginate(CursorPage)
         def get(self):
             return Pet.get()

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -87,13 +87,13 @@ the error response.
     class Pets(MethodView):
 
         @blp.arguments(PetQueryArgsSchema, location='query')
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         def get(self, args):
             """List pets"""
             return Pet.get(filters=args)
 
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema, code=201)
+        @blp.response(201, PetSchema)
         def post(self, new_data):
             """Add a new pet"""
             item = Pet.create(**new_data)
@@ -103,7 +103,7 @@ the error response.
     @blp.route('/<pet_id>')
     class PetsById(MethodView):
 
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def get(self, pet_id):
             """Get pet by ID"""
             try:
@@ -113,7 +113,7 @@ the error response.
             return item
 
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def put(self, update_data, pet_id):
             """Update existing pet"""
             try:
@@ -124,7 +124,7 @@ the error response.
             item.commit()
             return item
 
-        @blp.response(code=204)
+        @blp.response(204)
         def delete(self, pet_id):
             """Delete pet"""
             try:

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -4,9 +4,9 @@
 Response
 ========
 
-Use :meth:`Blueprint.response <Blueprint.response>` to specify a
-:class:`Schema <marshmallow.Schema>` class or instance to serialize the
-response and a status code (defaults to ``200``).
+Use :meth:`Blueprint.response <Blueprint.response>` to specify a status code
+and a :class:`Schema <marshmallow.Schema>` class or instance to serialize the
+response.
 
 In the following examples, the ``GET`` and ``PUT`` methods return an instance
 of ``Pet`` serialized with ``PetSchema``:
@@ -17,12 +17,12 @@ of ``Pet`` serialized with ``PetSchema``:
     @blp.route('/<pet_id>')
     class PetsById(MethodView):
 
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def get(self, pet_id):
             return Pet.get_by_id(pet_id)
 
         @blp.arguments(PetSchema)
-        @blp.response(PetSchema)
+        @blp.response(200, PetSchema)
         def put(self, update_data, pet_id):
             pet = Pet.get_by_id(pet_id)
             pet.update(update_data)
@@ -36,7 +36,7 @@ Here, the ``DELETE`` returns an empty response so no schema is specified.
     @blp.route('/<pet_id>')
     class PetsById(MethodView):
 
-        @blp.response(code=204)
+        @blp.response(204)
         def delete(self, pet_id):
             Pet.delete(pet_id)
 
@@ -49,11 +49,6 @@ If a view function returns a list of objects, the :class:`Schema
     @blp.route('/')
     class Pets(MethodView):
 
-        @blp.response(PetSchema(many=True))
+        @blp.response(200, PetSchema(many=True))
         def get(self, args):
             return Pet.get()
-
-.. note:: Even if a view function returns an empty response with a default
-   ``200`` code, decorating it with 
-   :meth:`Blueprint.response <Blueprint.response>` is useful anyway, to return
-   a proper Flask :class:`Response <flask.Response>` object.

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -18,15 +18,15 @@ class ResponseMixin:
     """Extend Blueprint to add response handling"""
 
     def response(
-            self, schema=None, *, code=200, description=None,
+            self, code, schema=None, *, description=None,
             example=None, examples=None, headers=None
     ):
         """Decorator generating an endpoint response
 
+        :param int|str|HTTPStatus code: HTTP status code.
+            Used if none is returned from the view function.
         :param schema: :class:`Schema <marshmallow.Schema>` class or instance.
             If not None, will be used to serialize response data.
-        :param int|str|HTTPStatus code: HTTP status code (default: 200).
-            Used if none is returned from the view function.
         :param str description: Description of the response (default: None).
         :param dict example: Example of response message.
         :param list examples: Examples of response message.

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -461,7 +461,7 @@ class TestBlueprint:
 
         @blp.route('/', methods=('GET', 'POST', ))
         @blp.arguments(schemas.DocSchema)
-        @blp.response(schemas.DocSchema)
+        @blp.response(200, schemas.DocSchema)
         def func(document, query_args):
             pass
 
@@ -502,12 +502,12 @@ class TestBlueprint:
         blp = Blueprint('test', 'test', url_prefix='/test')
 
         @blp.route('/schema_many_false')
-        @blp.response(schemas.DocSchema(many=False))
+        @blp.response(200, schemas.DocSchema(many=False))
         def many_false():
             pass
 
         @blp.route('/schema_many_true')
-        @blp.response(schemas.DocSchema(many=True))
+        @blp.response(200, schemas.DocSchema(many=True))
         def many_true():
             pass
 
@@ -540,12 +540,12 @@ class TestBlueprint:
         blp = Blueprint('test', 'test', url_prefix='/test')
 
         @blp.route('/route_1')
-        @blp.response(code=204)
+        @blp.response(204)
         def func_1():
             pass
 
         @blp.route('/route_2')
-        @blp.response(code=204, description='Test')
+        @blp.response(204, description='Test')
         def func_2():
             pass
 
@@ -568,7 +568,7 @@ class TestBlueprint:
         example = {'name': 'One'}
 
         @blp.route('/')
-        @blp.response(example=example)
+        @blp.response(200, example=example)
         def func():
             pass
 
@@ -595,7 +595,7 @@ class TestBlueprint:
         }
 
         @blp.route('/')
-        @blp.response(examples=examples)
+        @blp.response(200, examples=examples)
         def func():
             pass
 
@@ -612,7 +612,7 @@ class TestBlueprint:
         headers = {'X-Header': {'description': 'Custom header'}}
 
         @blp.route('/')
-        @blp.response(headers=headers)
+        @blp.response(200, headers=headers)
         def func():
             pass
 
@@ -802,7 +802,7 @@ class TestBlueprint:
             @blp.doc(**{'requestBody': doc_example})
             @blp.doc(**{'responses': {200: doc_example}})
             @blp.arguments(ItemSchema)
-            @blp.response(ItemSchema)
+            @blp.response(200, ItemSchema)
             def get(self):
                 pass
 
@@ -835,7 +835,7 @@ class TestBlueprint:
             # (Default is 200 expressed as int.)
             @blp.doc(**{'responses': {status_code: doc_desc}})
             @blp.arguments(ItemSchema)
-            @blp.response(ItemSchema, code=status_code)
+            @blp.response(status_code, ItemSchema)
             def get(self):
                 pass
 
@@ -964,42 +964,42 @@ class TestBlueprint:
         client = app.test_client()
 
         @blp.route('/response')
-        @blp.response()
+        @blp.response(200)
         def func_response():
             return {}
 
         @blp.route('/response_code_int')
-        @blp.response()
+        @blp.response(200)
         def func_response_code_int():
             return {}, 201
 
         @blp.route('/response_code_str')
-        @blp.response()
+        @blp.response(200)
         def func_response_code_str():
             return {}, '201 CREATED'
 
         @blp.route('/response_headers')
-        @blp.response()
+        @blp.response(200)
         def func_response_headers():
             return {}, {'X-header': 'test'}
 
         @blp.route('/response_code_int_headers')
-        @blp.response()
+        @blp.response(200)
         def func_response_code_int_headers():
             return {}, 201, {'X-header': 'test'}
 
         @blp.route('/response_code_str_headers')
-        @blp.response()
+        @blp.response(200)
         def func_response_code_str_headers():
             return {}, '201 CREATED', {'X-header': 'test'}
 
         @blp.route('/response_wrong_tuple')
-        @blp.response()
+        @blp.response(200)
         def func_response_wrong_tuple():
             return {}, 201, {'X-header': 'test'}, 'extra'
 
         @blp.route('/response_tuple_subclass')
-        @blp.response()
+        @blp.response(200)
         def func_response_tuple_subclass():
             class MyTuple(tuple):
                 pass
@@ -1044,37 +1044,37 @@ class TestBlueprint:
         client = app.test_client()
 
         @blp.route('/response')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate(Page)
         def func_response():
             return [1, 2]
 
         @blp.route('/response_code')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate(Page)
         def func_response_code():
             return [1, 2], 201
 
         @blp.route('/response_headers')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate(Page)
         def func_response_headers():
             return [1, 2], {'X-header': 'test'}
 
         @blp.route('/response_code_headers')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate(Page)
         def func_response_code_headers():
             return [1, 2], 201, {'X-header': 'test'}
 
         @blp.route('/response_wrong_tuple')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate(Page)
         def func_response_wrong_tuple():
             return [1, 2], 201, {'X-header': 'test'}, 'extra'
 
         @blp.route('/response_tuple_subclass')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate(Page)
         def func_response_tuple_subclass():
             class MyTuple(tuple):
@@ -1110,7 +1110,7 @@ class TestBlueprint:
 
         @blp.route('/response')
         # Schema is ignored when response object is returned
-        @blp.response(schemas.DocSchema, code=200)
+        @blp.response(200, schemas.DocSchema)
         def func_response():
             return flask.jsonify({"test": "test"}), 201, {'X-header': 'test'}
 

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -36,14 +36,13 @@ def app_with_etag(request, collection, schemas, app):
         class Resource(MethodView):
 
             @blp.etag(DocEtagSchema(many=True))
-            @blp.response(
-                DocSchema(many=True))
+            @blp.response(200, DocSchema(many=True))
             def get(self):
                 return collection.items
 
             @blp.etag(DocEtagSchema)
             @blp.arguments(DocSchema)
-            @blp.response(DocSchema, code=201)
+            @blp.response(201, DocSchema)
             def post(self, new_item):
                 return collection.post(new_item)
 
@@ -57,20 +56,20 @@ def app_with_etag(request, collection, schemas, app):
                     abort(404)
 
             @blp.etag(DocEtagSchema)
-            @blp.response(DocSchema)
+            @blp.response(200, DocSchema)
             def get(self, item_id):
                 return self._get_item(item_id)
 
             @blp.etag(DocEtagSchema)
             @blp.arguments(DocSchema)
-            @blp.response(DocSchema)
+            @blp.response(200, DocSchema)
             def put(self, new_item, item_id):
                 item = self._get_item(item_id)
                 blp.check_etag(item, DocEtagSchema)
                 return collection.put(item_id, new_item)
 
             @blp.etag(DocEtagSchema)
-            @blp.response(code=204)
+            @blp.response(204)
             def delete(self, item_id):
                 item = self._get_item(item_id)
                 blp.check_etag(item, DocEtagSchema)
@@ -79,14 +78,14 @@ def app_with_etag(request, collection, schemas, app):
     else:
         @blp.route('/')
         @blp.etag(DocEtagSchema(many=True))
-        @blp.response(DocSchema(many=True))
+        @blp.response(200, DocSchema(many=True))
         def get_resources():
             return collection.items
 
         @blp.route('/', methods=('POST',))
         @blp.etag(DocEtagSchema)
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema, code=201)
+        @blp.response(201, DocSchema)
         def post_resource(new_item):
             return collection.post(new_item)
 
@@ -98,14 +97,14 @@ def app_with_etag(request, collection, schemas, app):
 
         @blp.route('/<int:item_id>')
         @blp.etag(DocEtagSchema)
-        @blp.response(DocSchema)
+        @blp.response(200, DocSchema)
         def get_resource(item_id):
             return _get_item(item_id)
 
         @blp.route('/<int:item_id>', methods=('PUT',))
         @blp.etag(DocEtagSchema)
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema)
+        @blp.response(200, DocSchema)
         def put_resource(new_item, item_id):
             item = _get_item(item_id)
             blp.check_etag(item)
@@ -113,7 +112,7 @@ def app_with_etag(request, collection, schemas, app):
 
         @blp.route('/<int:item_id>', methods=('DELETE',))
         @blp.etag(DocEtagSchema)
-        @blp.response(code=204)
+        @blp.response(204)
         def delete_resource(item_id):
             item = _get_item(item_id)
             blp.check_etag(item)
@@ -438,7 +437,7 @@ class TestEtag:
 
         @blp.route('/')
         @blp.etag
-        @blp.response()
+        @blp.response(200)
         def func_response_etag():
             # When the view function returns a Response object,
             # the ETag must be specified manually

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,14 +30,14 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
     class Resource(MethodView):
 
         @blp.etag
-        @blp.response(DocSchema(many=True))
+        @blp.response(200, DocSchema(many=True))
         @blp.paginate(Page)
         def get(self):
             return collection.items
 
         @blp.etag
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema)
+        @blp.response(201, DocSchema)
         def post(self, new_item):
             return collection.post(new_item)
 
@@ -51,13 +51,13 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
                 abort(404)
 
         @blp.etag
-        @blp.response(DocSchema)
+        @blp.response(200, DocSchema)
         def get(self, item_id):
             return self._get_item(item_id)
 
         @blp.etag
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema)
+        @blp.response(200, DocSchema)
         def put(self, new_item, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action and schema must be provided
@@ -65,7 +65,7 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
             return collection.put(item_id, new_item)
 
         @blp.etag
-        @blp.response(code=204)
+        @blp.response(204)
         def delete(self, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action and schema must be provided
@@ -90,7 +90,7 @@ def implicit_data_explicit_schema_etag_blueprint(collection, schemas):
     class Resource(MethodView):
 
         @blp.etag(DocEtagSchema(many=True))
-        @blp.response(DocSchema(many=True))
+        @blp.response(200, DocSchema(many=True))
         @blp.paginate()
         def get(self, pagination_parameters):
             pagination_parameters.item_count = len(collection.items)
@@ -101,7 +101,7 @@ def implicit_data_explicit_schema_etag_blueprint(collection, schemas):
 
         @blp.etag(DocEtagSchema)
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema)
+        @blp.response(201, DocSchema)
         def post(self, new_item):
             return collection.post(new_item)
 
@@ -115,14 +115,14 @@ def implicit_data_explicit_schema_etag_blueprint(collection, schemas):
                 abort(404)
 
         @blp.etag(DocEtagSchema)
-        @blp.response(DocSchema)
+        @blp.response(200, DocSchema)
         def get(self, item_id):
             item = self._get_item(item_id)
             return item
 
         @blp.etag(DocEtagSchema)
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema)
+        @blp.response(200, DocSchema)
         def put(self, new_item, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action, ETag schema is used
@@ -131,7 +131,7 @@ def implicit_data_explicit_schema_etag_blueprint(collection, schemas):
             return new_item
 
         @blp.etag(DocEtagSchema)
-        @blp.response(code=204)
+        @blp.response(204)
         def delete(self, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action, ETag schema is used
@@ -157,7 +157,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
     class Resource(MethodView):
 
         @blp.etag
-        @blp.response(DocSchema(many=True))
+        @blp.response(200, DocSchema(many=True))
         @blp.paginate()
         def get(self, pagination_parameters):
             pagination_parameters.item_count = len(collection.items)
@@ -170,7 +170,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
 
         @blp.etag
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema)
+        @blp.response(201, DocSchema)
         def post(self, new_item):
             # Compute ETag using arbitrary data and no schema
             blp.set_etag(new_item['db_field'])
@@ -186,7 +186,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
                 abort(404)
 
         @blp.etag
-        @blp.response(DocSchema)
+        @blp.response(200, DocSchema)
         def get(self, item_id):
             item = self._get_item(item_id)
             # Compute ETag using arbitrary data and no schema
@@ -195,7 +195,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
 
         @blp.etag
         @blp.arguments(DocSchema)
-        @blp.response(DocSchema)
+        @blp.response(200, DocSchema)
         def put(self, new_item, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action, no shema used
@@ -206,7 +206,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
             return new_item
 
         @blp.etag
-        @blp.response(code=204)
+        @blp.response(204)
         def delete(self, item_id):
             item = self._get_item(item_id)
             # Check ETag is a manual action, no shema used
@@ -276,7 +276,7 @@ class TestFullExample:
                 data=json.dumps(item_1_data),
                 content_type='application/json'
             )
-        assert response.status_code == 200
+        assert response.status_code == 201
         item_1_id = response.json['item_id']
 
         # GET collection with wrong/outdated ETag: OK
@@ -373,7 +373,7 @@ class TestFullExample:
                 data=json.dumps(item_2_data),
                 content_type='application/json'
             )
-        assert response.status_code == 200
+        assert response.status_code == 201
 
         # GET collection with pagination set to 1 element per page
         # Content is the same (item_1) but pagination metadata has changed
@@ -449,7 +449,7 @@ class TestCustomExamples:
         blp = WrapperBlueprint('test', __name__, url_prefix='/test')
 
         @blp.route('/')
-        @blp.response(schemas.DocSchema)
+        @blp.response(200, schemas.DocSchema)
         def func():
             return {'item_id': 1, 'db_field': 42}
 
@@ -535,7 +535,7 @@ class TestCustomExamples:
         blp = WrapperBlueprint('test', __name__, url_prefix='/test')
 
         @blp.route('/')
-        @blp.response(schemas.DocSchema(many=True))
+        @blp.response(200, schemas.DocSchema(many=True))
         @blp.paginate(Page)
         def func():
             return [

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -29,7 +29,7 @@ def pagination_blueprint(collection, schemas, as_method_view, custom_params):
     if as_method_view:
         @blp.route('/')
         class Resource(MethodView):
-            @blp.response(schemas.DocSchema(many=True))
+            @blp.response(200, schemas.DocSchema(many=True))
             @blp.paginate(
                 page=page, page_size=page_size, max_page_size=max_page_size)
             def get(self, pagination_parameters):
@@ -40,7 +40,7 @@ def pagination_blueprint(collection, schemas, as_method_view, custom_params):
                 ]
     else:
         @blp.route('/')
-        @blp.response(schemas.DocSchema(many=True))
+        @blp.response(200, schemas.DocSchema(many=True))
         @blp.paginate(
             page=page, page_size=page_size, max_page_size=max_page_size)
         def get_resources(pagination_parameters):
@@ -67,14 +67,14 @@ def post_pagination_blueprint(
     if as_method_view:
         @blp.route('/')
         class Resource(MethodView):
-            @blp.response(schemas.DocSchema(many=True))
+            @blp.response(200, schemas.DocSchema(many=True))
             @blp.paginate(Page, page=page,
                           page_size=page_size, max_page_size=max_page_size)
             def get(self):
                 return collection.items
     else:
         @blp.route('/')
-        @blp.response(schemas.DocSchema(many=True))
+        @blp.response(200, schemas.DocSchema(many=True))
         @blp.paginate(Page, page=page,
                       page_size=page_size, max_page_size=max_page_size)
         def get_resources():
@@ -129,7 +129,7 @@ class TestPagination:
         blp = CustomBlueprint('test', __name__, url_prefix='/test')
 
         @blp.route('/')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate()
         def func(pagination_parameters):
             pagination_parameters.item_count = 2
@@ -158,7 +158,7 @@ class TestPagination:
         blp = CustomBlueprint('test', __name__, url_prefix='/test')
 
         @blp.route('/')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate()
         def func(pagination_parameters):
             """Dummy view func"""
@@ -185,7 +185,7 @@ class TestPagination:
         blp = CustomBlueprint('test', __name__, url_prefix='/test')
 
         @blp.route('/')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate()
         def func(pagination_parameters):
             # Here, we purposely forget to set item_count
@@ -319,7 +319,7 @@ class TestPagination:
         blp = Blueprint('test', __name__, url_prefix='/test')
 
         @blp.route('/')
-        @blp.response()
+        @blp.response(200)
         @blp.paginate(Page)
         def func():
             return range(30)
@@ -347,7 +347,7 @@ class TestPagination:
 
         @blp.route('/')
         @blp.arguments(schemas.QueryArgsSchema, location="query")
-        @blp.response()
+        @blp.response(200)
         @blp.paginate(Page)
         def func(query_args):
             assert query_args['arg1'] == 'Test'


### PR DESCRIPTION
This change would make the signature consistent with the alternate response decorator in upcoming #159.

```py
    def response(
            self, code, schema=None, *, description=None,
            example=None, examples=None, headers=None
    ):
```

Example:

```py
        @blp.etag
        @blp.response(200, DocSchema(many=True))
        @blp.paginate(Page)
        def get(self):
            return collection.items
```

My typical resources use the following codes

```py
/items/

  GET 200
  POST 201

/items/idem_id

  GET 200
  PUT 200
  DELETE 204
```

so 2 times out of 5, the default value of 200 has to be overridden already.

There is no real reason to default to 200, apart from statistics saying it is the most used response code.

It would also make the codes aligned in the code accross view functions, so a typo may appear more clearly.

Overall, I find it more logical this way. Explicit better than implicit, etc.

On the other hand, this change means going through the codebase to fix all calls to `@response`...