### PR TITLE
Fix passing field metadata as kwargs (deprecated)

### DIFF
--- a/flask_smorest/error_handler.py
+++ b/flask_smorest/error_handler.py
@@ -9,10 +9,10 @@ class ErrorSchema(ma.Schema):
 
     Not actually used to dump payload, but only for documentation purposes
     """
-    code = ma.fields.Integer(description='Error code')
-    status = ma.fields.String(description='Error name')
-    message = ma.fields.String(description='Error message')
-    errors = ma.fields.Dict(description='Errors')
+    code = ma.fields.Integer(metadata={"description": "Error code"})
+    status = ma.fields.String(metadata={"description": "Error name"})
+    message = ma.fields.String(metadata={"description": "Error message"})
+    errors = ma.fields.Dict(metadata={"description": "Errors"})
 
 
 class ErrorHandlerMixin:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         'werkzeug>=0.15,<2',
         'flask>=1.1.0,<2',
-        'marshmallow>=3.0.0,<4',
+        'marshmallow>=3.10.0,<4',
         'webargs>=7.0.0,<8',
         'apispec>=4.0.0,<5',
     ],


### PR DESCRIPTION
Passing field metadata as kwargs is deprecated in marshmallow 3.10.

https://github.com/marshmallow-code/marshmallow/pull/1702