### PR TITLE
Only add referenced responses to the spec

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Contributors (chronological)
 - Jón Bjarnason `@nonnib <https://github.com/nonnib>`_
 - Igor Davydenko `@playpauseandstop <https://github.com/playpauseandstop>`_
 - Joshua Harrison `@joshua-harrison-2011 <https://github.com/joshua-harrison-2011>`_
+- Martin Roy `@lindycoder <https://github.com/lindycoder>`_

--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -70,9 +70,6 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         # Register error handlers
         self._register_error_handlers()
 
-        # Register responses
-        self._register_responses()
-
     def register_blueprint(self, blp, **options):
         """Register a blueprint in the application
 

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -3,6 +3,7 @@ import json
 import http
 
 import flask
+from apispec import BasePlugin
 from flask import current_app
 import click
 import apispec
@@ -12,6 +13,7 @@ from flask_smorest.exceptions import MissingAPIParameterError
 from flask_smorest.utils import prepare_response
 from .plugins import FlaskPlugin
 from .field_converters import uploadfield2properties
+from ..error_handler import ErrorSchema
 
 
 def _add_leading_slash(string):
@@ -114,12 +116,15 @@ class APISpecMixin(DocBlueprintMixin):
             self, *,
             flask_plugin=None, marshmallow_plugin=None, extra_plugins=None,
             title=None, version=None, openapi_version=None,
+            response_plugin=None,
             **options
     ):
         # Plugins
         self.flask_plugin = flask_plugin or FlaskPlugin()
         self.ma_plugin = marshmallow_plugin or MarshmallowPlugin()
-        plugins = [self.flask_plugin, self.ma_plugin]
+        self.resp_plugin = (response_plugin
+                            or RefResponsesPlugin(self.ERROR_SCHEMA))
+        plugins = [self.flask_plugin, self.ma_plugin, self.resp_plugin]
         plugins.extend(extra_plugins or ())
 
         # APISpec options
@@ -246,25 +251,62 @@ class APISpecMixin(DocBlueprintMixin):
     def _register_field(self, field, *args):
         self.ma_plugin.map_to_openapi_type(*args)(field)
 
-    def _register_responses(self):
-        """Register default responses for all status codes"""
-        # Register a response for each status code
-        for status in http.HTTPStatus:
-            response = {
-                'description': status.phrase,
-                'schema': self.ERROR_SCHEMA,
-            }
-            prepare_response(
-                response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
-            self.spec.components.response(status.name, response)
 
-        # Also register a default error response
-        response = {
-            'description': 'Default error response',
-            'schema': self.ERROR_SCHEMA,
+class RefResponsesPlugin(BasePlugin):
+    """Plugin to add responses to spec."""
+
+    def __init__(self, default_error_schema=ErrorSchema,
+                 default_response_content_type=DEFAULT_RESPONSE_CONTENT_TYPE):
+        self.error_schema = default_error_schema
+        self.content_type = default_response_content_type
+
+        self._available = self._available_responses()
+        self._registered = set()
+
+    def init_spec(self, spec):
+        super().init_spec(spec)
+        self.spec = spec
+
+    def operation_helper(self, operations=None, **kwargs):
+        """Inspired by MarshmallowPlugin.operation_helper
+
+        Looking for `str` responses, adding the corresponding spec responses.
+        `APISpec.clean_operations` will add a $ref for any response that is not
+        a `dict`, it's this plugin's role to ensure that $ref rexists.
+        """
+        for operation in (operations or {}).values():
+            if not isinstance(operation, dict):
+                continue
+            for response in operation.get("responses", {}).values():
+                if (isinstance(response, str)
+                        and response in self._available
+                        and response not in self._registered):
+
+                    self._add_to_spec(response)
+
+    def _add_to_spec(self, response):
+        resp = self._available[response]
+        prepare_response(resp, self.spec, self.content_type)
+        self.spec.components.response(response, resp)
+        self._registered.add(response)
+
+    def _available_responses(self):
+        """Build responses for all status codes."""
+        responses = {
+            status.name: {
+                'description': status.phrase,
+                'schema': self.error_schema,
+            }
+            for status in http.HTTPStatus
         }
-        prepare_response(response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
-        self.spec.components.response('DEFAULT_ERROR', response)
+
+        # Also add a default error response
+        responses['DEFAULT_ERROR'] = {
+            'description': 'Default error response',
+            'schema': self.error_schema,
+        }
+
+        return responses
 
 
 openapi_cli = flask.cli.AppGroup('openapi', help='OpenAPI commands.')

--- a/flask_smorest/spec/constants.py
+++ b/flask_smorest/spec/constants.py
@@ -1,0 +1,4 @@
+"""Constants"""
+
+DEFAULT_REQUEST_BODY_CONTENT_TYPE = 'application/json'
+DEFAULT_RESPONSE_CONTENT_TYPE = 'application/json'

--- a/flask_smorest/spec/plugins.py
+++ b/flask_smorest/spec/plugins.py
@@ -1,14 +1,14 @@
-"""Flask plugin
-
-Heavily copied from apispec
-"""
-
+"""apispec plugins"""
 from collections.abc import Mapping
+import http
 import re
 
 import werkzeug.routing
-
 from apispec import BasePlugin
+
+from flask_smorest.utils import prepare_response
+from flask_smorest.error_handler import ErrorSchema
+from .constants import DEFAULT_RESPONSE_CONTENT_TYPE
 
 
 # from flask-restplus
@@ -78,8 +78,10 @@ DEFAULT_CONVERTER_MAPPING = {
 
 
 class FlaskPlugin(BasePlugin):
-    """Plugin to create OpenAPI paths from Flask rules"""
+    """Plugin to create OpenAPI paths from Flask rules
 
+    Heavily copied from apispec.
+    """
     def __init__(self):
         super().__init__()
         self.converter_mapping = dict(DEFAULT_CONVERTER_MAPPING)
@@ -156,3 +158,69 @@ class FlaskPlugin(BasePlugin):
                 parameters.append(path_p)
 
         return self.flaskpath2openapi(rule.rule)
+
+
+class ResponseReferencesPlugin(BasePlugin):
+    """Plugin to add responses to spec
+
+    This plugin automatically adds a response component for default responses
+    on-the-fly when it is referenced in an operation.
+
+    It applies to all HTTP status responses and to the default error response,
+    allowing the user to pass responses as string like
+    "UNPROCESSABLE_ENTITY" or "DEFAULT_ERROR".
+
+    :param error_schema: :class:`Schema <marshmallow.Schema>` defining the
+        error response structure.
+    :param str content_type: Content type used in default responses.
+    """
+    def __init__(
+            self,
+            error_schema=ErrorSchema,
+            response_content_type=DEFAULT_RESPONSE_CONTENT_TYPE
+    ):
+        self.error_schema = error_schema
+        self.content_type = response_content_type
+        self._available = self._available_responses()
+        self._registered = set()
+
+    def init_spec(self, spec):
+        super().init_spec(spec)
+        self.spec = spec
+
+    def operation_helper(self, operations=None, **kwargs):
+        """Inspired by MarshmallowPlugin.operation_helper
+
+        Looking for `str` responses, adding the corresponding spec responses.
+        `APISpec.clean_operations` will add a $ref for any response that is not
+        a `dict`, it's this plugin's role to ensure that $ref exists.
+        """
+        for operation in (operations or {}).values():
+            if not isinstance(operation, dict):
+                continue
+            for response in operation.get("responses", {}).values():
+                if (
+                        isinstance(response, str)
+                        and response not in self._registered
+                        and response in self._available
+                ):
+                    resp = self._available[response]
+                    prepare_response(resp, self.spec, self.content_type)
+                    self.spec.components.response(response, resp)
+                    self._registered.add(response)
+
+    def _available_responses(self):
+        """Build responses for all status codes."""
+        responses = {
+            status.name: {
+                'description': status.phrase,
+                'schema': self.error_schema,
+            }
+            for status in http.HTTPStatus
+        }
+        # Also add a default error response
+        responses['DEFAULT_ERROR'] = {
+            'description': 'Default error response',
+            'schema': self.error_schema,
+        }
+        return responses

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 """Test Api class"""
-
+import copy
 import http
 
 import pytest
@@ -11,8 +11,9 @@ import apispec
 
 from flask_smorest import Api, Blueprint
 from flask_smorest.exceptions import MissingAPIParameterError
+from flask_smorest.spec import RefResponsesPlugin
 
-from .utils import get_schemas, get_responses, build_ref
+from .utils import get_schemas
 
 
 class TestApi:
@@ -409,25 +410,52 @@ class TestApi:
         ):
             Api(app)
 
+
+class TestRefResponsesPlugin:
+    """Test RefResponsesPlugin class"""
+
+    @pytest.mark.parametrize('kwargs', [
+        ({}),
+        ({'operations': None}),
+        ({'operations': {}}),
+        ({'operations': {'get': 'not a dict'}}),
+        ({'operations': {'get': {}}}),
+        ({'operations': {'get': {'responses': {}}}}),
+        ({'operations': {'get': {'responses': {200: {}}}}}),
+        ({'operations': {'get': {'responses': {200: 'unknown response'}}}}),
+    ])
+    def test_operation_helper_unapplicable(self, kwargs):
+        """Should ignore if there are no applicable responses.
+
+        Applicable responses are string in the defined applicable responses.
+        Any other cases should pass right through without changing anything.
+        """
+        plugin = RefResponsesPlugin()
+        expected = copy.deepcopy(kwargs)
+        plugin.operation_helper(**kwargs)
+        assert kwargs == expected  # Nothing mutated
+
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
-    def test_api_registers_error_responses(self, app, openapi_version):
-        """Test default error responses are registered"""
-        app.config['OPENAPI_VERSION'] = openapi_version
-        api = Api(app)
-        responses = get_responses(api.spec)
-        assert 'Error' in get_schemas(api.spec)
-        for status in http.HTTPStatus:
-            if openapi_version == '2.0':
-                assert responses[status.name] == {
-                    'description': status.phrase,
-                    'schema': build_ref(api.spec, 'schema', 'Error'),
-                }
-            else:
-                assert responses[status.name] == {
-                    'description': status.phrase,
-                    'content': {
-                        'application/json': {
-                            'schema': build_ref(api.spec, 'schema', 'Error')
-                        }
-                    }
-                }
+    @pytest.mark.parametrize('http_status_code, http_status_name', [
+        *[(s.value, s.name) for s in http.HTTPStatus],
+        ('DEFAULT_ERROR', 'DEFAULT_ERROR'),
+    ])
+    def test_api_registers_error_responses(
+            self, openapi_version, http_status_code, http_status_name):
+        """Responses should be added to spec."""
+        spec = apispec.APISpec('title', 'version', openapi_version)
+
+        operations = {'get': {'responses': {
+            http_status_code: http_status_name,
+        }}}
+
+        plugin = RefResponsesPlugin()
+        plugin.init_spec(spec)
+        plugin.operation_helper(operations=operations)
+
+        components = spec.to_dict()
+        if openapi_version == '3.0.2':
+            components = components['components']
+
+        assert len(components['responses']) == 1
+        assert http_status_name in components['responses']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ import apispec
 
 from flask_smorest import Api, Blueprint
 from flask_smorest.exceptions import MissingAPIParameterError
-from flask_smorest.spec import RefResponsesPlugin
+from flask_smorest.spec import ResponseReferencesPlugin
 
 from .utils import get_schemas
 
@@ -430,7 +430,7 @@ class TestRefResponsesPlugin:
         Applicable responses are string in the defined applicable responses.
         Any other cases should pass right through without changing anything.
         """
-        plugin = RefResponsesPlugin()
+        plugin = ResponseReferencesPlugin()
         expected = copy.deepcopy(kwargs)
         plugin.operation_helper(**kwargs)
         assert kwargs == expected  # Nothing mutated
@@ -444,7 +444,7 @@ class TestRefResponsesPlugin:
             self, openapi_version, http_status_code, http_status_name):
         """Responses should be added to spec."""
         spec = apispec.APISpec('title', 'version', openapi_version)
-        plugin = RefResponsesPlugin()
+        plugin = ResponseReferencesPlugin()
         plugin.init_spec(spec)
 
         operations = {'get': {'responses': {
@@ -464,7 +464,7 @@ class TestRefResponsesPlugin:
     def test_multi_operation_multi_reponses(self, openapi_version):
         """Should loop all operations and all responses."""
         spec = apispec.APISpec('title', 'version', openapi_version)
-        plugin = RefResponsesPlugin()
+        plugin = ResponseReferencesPlugin()
         plugin.init_spec(spec)
 
         operations = {
@@ -494,7 +494,7 @@ class TestRefResponsesPlugin:
     def test_repeated_response(self, openapi_version):
         """Repeated response, different endpoint."""
         spec = apispec.APISpec('title', 'version', openapi_version)
-        plugin = RefResponsesPlugin()
+        plugin = ResponseReferencesPlugin()
         plugin.init_spec(spec)
 
         operations = {'get': {'responses': {

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -15,8 +15,7 @@ from flask_smorest import Api, Blueprint, Page
 from flask_smorest.fields import Upload
 
 
-from .utils import build_ref
-
+from .utils import build_ref, get_responses
 
 LOCATIONS_MAPPING = (
     ('querystring', 'query',),
@@ -396,6 +395,7 @@ class TestBlueprint:
             spec['paths']['/test/']['get']['responses'][str(error_code)] ==
             build_ref(api.spec, 'response', http.HTTPStatus(error_code).name)
         )
+        assert http.HTTPStatus(error_code).name in get_responses(api.spec)
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
     def test_blueprint_route_parameters(self, app, openapi_version):


### PR DESCRIPTION
The process of adding responses dynamically to endpoints is relying on
adding the HTTP Status name as the response instead of an dict
referencing a schema.  This causes marsmallow to interpret it as a
reference so the reference has to exist.

Instead of adding all the possible responses to the spec, only the
responses referenced in any endpoints are added when necessary.  This
reduces noise in the spec while keeping the feature intact.

Fixes #206


==========

Good day sir,

What do you think of this approach?