### PR TITLE
Add a flag to disable default_errors

### DIFF
--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -69,6 +69,7 @@ class Blueprint(
     def __init__(self, *args, **kwargs):
 
         self.description = kwargs.pop('description', '')
+        self.auto_default_error = kwargs.pop('auto_default_error', True)
 
         super().__init__(*args, **kwargs)
 

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -102,8 +102,9 @@ class ResponseMixin:
 
                 return resp
 
-            # Document default error response
-            doc['responses']['default'] = 'DEFAULT_ERROR'
+            if self.auto_default_error:  # from Blueprint
+                # Document default error response
+                doc['responses']['default'] = 'DEFAULT_ERROR'
 
             # Store doc in wrapper function
             # The deepcopy avoids modifying the wrapped function doc

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -637,6 +637,21 @@ class TestBlueprint:
             api.spec, 'response', 'DEFAULT_ERROR'
         )
 
+    def test_blueprint_response_documents_default_no_error_response(self, app):
+        api = Api(app)
+        blp = Blueprint('test', 'test', url_prefix='/test',
+                        auto_default_error=False)
+
+        @blp.route('/')
+        @blp.response()
+        def func():
+            pass
+
+        api.register_blueprint(blp)
+
+        get = api.spec.to_dict()['paths']['/test/']['get']
+        assert 'default' not in get['responses']
+
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
     def test_blueprint_pagination(self, app, schemas, openapi_version):
         app.config['OPENAPI_VERSION'] = openapi_version


### PR DESCRIPTION
Specified on the blueprint, this will skip adding default_error
responses automatically to endpoints, leaving the consumer to manually
manage those defaults.

Fixes #209 

========

It's me again!
Tell me what you think of this approach, I originally wanted to make this a flask app config, such as the `OPENAPI_*` configs, but endpoints are registered on the blueprint prior to initializing the flask app.

Having this on the blueprint level also allows consumers to subclass Blueprint and make it a default False if they have several blueprints.