### PR TITLE
Make DEFAULT_ERROR optional (opt-out)

### DIFF
--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -84,7 +84,7 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         self._app.register_blueprint(blp, **options)
 
         # Register views in API documentation for this resource
-        blp.register_views_in_doc(self._app, self.spec)
+        blp.register_views_in_doc(self, self._app, self.spec)
 
         # Add tag relative to this resource to the global tag list
         self.spec.tag({'name': blp.name, 'description': blp.description})

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -162,7 +162,7 @@ class Blueprint(
         # Store parameters doc info from route decorator
         endpoint_doc_info['parameters'] = parameters
 
-    def register_views_in_doc(self, app, spec):
+    def register_views_in_doc(self, api, app, spec):
         """Register views information in documentation
 
         If a schema in a parameter or a response appears in the spec
@@ -186,6 +186,7 @@ class Blueprint(
                     operation_doc = func(
                         operation_doc,
                         operation_doc_info,
+                        api=api,
                         app=app,
                         spec=spec,
                         method=method_l

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -102,9 +102,6 @@ class ResponseMixin:
 
                 return resp
 
-            # Document default error response
-            doc['responses']['default'] = 'DEFAULT_ERROR'
-
             # Store doc in wrapper function
             # The deepcopy avoids modifying the wrapped function doc
             wrapper._apidoc = deepcopy(getattr(wrapper, '_apidoc', {}))
@@ -155,7 +152,9 @@ class ResponseMixin:
 
     @staticmethod
     def _prepare_response_doc(doc, doc_info, *, spec, **kwargs):
-        operation = doc_info.get('response')
+        operation = doc_info.get('response', {})
+        # Document default error response
+        operation.setdefault('responses', {})['default'] = "DEFAULT_ERROR"
         if operation:
             for response in operation['responses'].values():
                 prepare_response(response, spec, DEFAULT_RESPONSE_CONTENT_TYPE)

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -151,10 +151,12 @@ class ResponseMixin:
         return data
 
     @staticmethod
-    def _prepare_response_doc(doc, doc_info, *, spec, **kwargs):
+    def _prepare_response_doc(doc, doc_info, *, api, spec, **kwargs):
         operation = doc_info.get('response', {})
         # Document default error response
-        operation.setdefault('responses', {})['default'] = "DEFAULT_ERROR"
+        if api.DEFAULT_ERROR_RESPONSE_NAME:
+            operation.setdefault('responses', {})['default'] = (
+                api.DEFAULT_ERROR_RESPONSE_NAME)
         if operation:
             for response in operation['responses'].values():
                 prepare_response(response, spec, DEFAULT_RESPONSE_CONTENT_TYPE)

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -107,6 +107,8 @@ class DocBlueprintMixin:
 class APISpecMixin(DocBlueprintMixin):
     """Add APISpec related features to Api class"""
 
+    DEFAULT_ERROR_RESPONSE_NAME = "DEFAULT_ERROR"
+
     def _init_spec(
             self,
             *,

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -621,12 +621,11 @@ class TestBlueprint:
         get = api.spec.to_dict()['paths']['/test/']['get']
         assert get['responses']['200']['headers'] == headers
 
-    def test_blueprint_response_documents_default_error_response(self, app):
+    def test_blueprint_documents_default_error_response(self, app):
         api = Api(app)
         blp = Blueprint('test', 'test', url_prefix='/test')
 
         @blp.route('/')
-        @blp.response()
         def func():
             pass
 


### PR DESCRIPTION
Replaces #210.
Closes  #209.

This PR

- makes the feature adding a default error optional (default: feature on)
- allows to choose the name of the default error in the spec (default: `"DEFAULT_ERROR"`, `None` disables the feature )
- ensures the default error is added to all resources (all functions decorated with `@route`, not only those decorated with `@response` (bug reported in #209)

As usual in flask-smorest, this is a class attribute. I deliberately didn't add an init parameter or a Flask app parameter for simplicity. I think the default is sensible and it is easy enough to subclass.

@lindycoder, what do you think about this implementation?

@lindycoder
> The personal issue i have with this is that i may not be documenting all responses, such as unexpected 500s and if they happens, there's no way they will respect the default schema, which is not at all enforced anyway.

My understanding is that the feature exists in OpenAPI spec as a shortcut to document similar responses as explained in https://swagger.io/docs/specification/describing-responses/. I added this default response in the docs because flask-smorest formats all errors with this structure, including 500 errors resulting from exceptions in the app. I don't think a client would blame the server for not complying on all server errors, like an error occurring at apache level. I mean there can always be a point were the server is so crashed it can't provide reliable results at all. So I'm not worried about this.

I'd be more worried about people adding custom decorators or decorators from other libs to implement features like authentication, rate limiting, etc. that wouldn't return a compliant error format. When I do so, I wrap the decorator to comply and to auto-document itself.



------------------------------------------------------

I'd like to release this along with #208.

This PR allows to go on with the #208 rework, declare the default error response on init and simplify `ResponseReferencesPlugin`.



