### PR TITLE
Allow manually registered HTTPStatus response

### DIFF
--- a/flask_smorest/spec/plugins.py
+++ b/flask_smorest/spec/plugins.py
@@ -182,7 +182,6 @@ class ResponseReferencesPlugin(BasePlugin):
         self.error_schema = error_schema
         self.content_type = response_content_type
         self._available = self._available_responses()
-        self._registered = set()
 
     def init_spec(self, spec):
         super().init_spec(spec)
@@ -201,13 +200,12 @@ class ResponseReferencesPlugin(BasePlugin):
             for response in operation.get("responses", {}).values():
                 if (
                         isinstance(response, str)
-                        and response not in self._registered
+                        and response not in self.spec.components.responses
                         and response in self._available
                 ):
                     resp = self._available[response]
                     prepare_response(resp, self.spec, self.content_type)
                     self.spec.components.response(response, resp)
-                    self._registered.add(response)
 
     def _available_responses(self):
         """Build responses for all status codes."""

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
         'flask>=1.1.0,<2',
         'marshmallow>=3.10.0,<4',
         'webargs>=7.0.0,<8',
-        'apispec>=4.0.0,<5',
+        'apispec>=4.2.0,<5',
     ],
 )


### PR DESCRIPTION
Allows a user to manually define responses overriding automatic HTTPStatus responses.

flask-smorest automatically defines responses when a HTTPStatus name is passed in an operation. This PR ensures that if such a response is already defined, it won't conflict (it won't raise) and the automatic definition will be skipped.

See #208 for background.

Not a breaking change except it bumps apispec min version to 4.2.0.