### PR TITLE
Use werkzeug.Response, not BaseResponse

### DIFF
--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from functools import wraps
 import http
 
-from werkzeug.wrappers import BaseResponse
+from werkzeug import Response
 from flask import jsonify
 
 from .utils import (
@@ -77,8 +77,8 @@ class ResponseMixin:
                 result_raw, status, headers = unpack_tuple_response(
                     func(*args, **kwargs))
 
-                # If return value is a werkzeug BaseResponse, return it
-                if isinstance(result_raw, BaseResponse):
+                # If return value is a werkzeug Response, return it
+                if isinstance(result_raw, Response):
                     set_status_and_headers_in_response(
                         result_raw, status, headers)
                     return result_raw


### PR DESCRIPTION
Shouldn't hurt with werkzeug < 2.

BaseResponse is deprecated in werkzeug 2.