### PR TITLE
Drop claim that CPython 3.6+ preserves Marshmallow schema order

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -250,9 +250,6 @@ This is typically done in a base class:
         name = ma.fields.String()
         surname = ma.fields.String()
 
-Passing ``ordered`` Meta attribute is not necessary when using a Python version
-for which dictionaries are always ordered (>= 3.7 or CPython 3.6).
-
 Serve the OpenAPI Documentation
 -------------------------------
 


### PR DESCRIPTION
Unfortunately, the actual Marshmallow `Schema` implementation that orders fields uses _sets_ and so doesn't honour schema field order.

Fixes #228