### PR TITLE
Use webargs>=8.0.0,<9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'werkzeug>=0.15,<2',
         'flask>=1.1.0,<2',
         'marshmallow>=3.10.0,<4',
-        'webargs>=7.0.0,<8',
+        'webargs>=8.0.0,<9',
         'apispec>=4.0.0,<5',
     ],
 )


### PR DESCRIPTION
This improves `unknown` fields behaviour.