### PR TITLE
Fix the type of examples in docstring

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Contributors (chronological)
 - Martin Roy `@lindycoder <https://github.com/lindycoder>`_
 - Martijn Pieters `@mjpieters <https://github.com/mjpieters>`_
 - Stephen Rosen `@sirosen <https://github.com/sirosen>`_
+- Grey Li `@greyli <https://github.com/greyli>`_

--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -33,7 +33,7 @@ class ArgumentsMixin:
         :param bool required: Whether argument is required (default: True).
         :param str description: Argument description.
         :param dict example: Parameter example.
-        :param list examples: List of parameter examples.
+        :param dict examples: Parameter examples.
         :param dict kwargs: Keyword arguments passed to the webargs
             :meth:`use_args <webargs.core.Parser.use_args>` decorator used
             internally.

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -29,7 +29,7 @@ class ResponseMixin:
             If not None, will be used to serialize response data.
         :param str description: Description of the response (default: None).
         :param dict example: Example of response message.
-        :param list examples: Examples of response message.
+        :param dict examples: Examples of response message.
         :param dict headers: Headers returned by the response.
 
         The decorated function is expected to return the same types of value
@@ -125,7 +125,7 @@ class ResponseMixin:
             When passing a reference, arguments below are ignored.
         :param str description: Description of the response (default: None).
         :param dict example: Example of response message.
-        :param list examples: Examples of response message.
+        :param dict examples: Examples of response message.
         :param dict headers: Headers returned by the response.
         """
         # If a ref is passed


### PR DESCRIPTION
The `examples` argument for the request/response body should be a dict ([ref](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#request-body-examples)).