### PR TITLE
Remove feature setting `basePath` from `APPLICATION_ROOT`

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -150,13 +150,6 @@ Note that ``app.config`` overrides ``spec_kwargs``. The example above produces
 
     {'host': 'example.com', 'x-internal-id': '2', ...}
 
-.. note:: Again, flask-smorest tries to provide as much information as
-   possible, but some values can only by provided by the user.
-
-   When using OpenAPI v2, `basePath` is automatically set from the value of the
-   flask parameter `APPLICATION_ROOT`. In OpenAPI v3, `basePath` is removed,
-   and the `servers` attribute can only be set by the user.
-
 Document Top-level Components
 -----------------------------
 

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -152,8 +152,6 @@ class APISpecMixin(DocBlueprintMixin):
             )
         openapi_major_version = int(openapi_version.split('.')[0])
         if openapi_major_version < 3:
-            base_path = self._app.config.get('APPLICATION_ROOT')
-            options.setdefault('basePath', base_path)
             options.setdefault(
                 'produces', [DEFAULT_RESPONSE_CONTENT_TYPE, ])
             options.setdefault(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -350,20 +350,6 @@ class TestApi:
         assert response.status_code == 200
         assert response.json == {'response': 'OK'}
 
-    @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
-    @pytest.mark.parametrize('base_path', [None, '/', '/v1'])
-    def test_api_apispec_sets_base_path(self, app, openapi_version, base_path):
-        app.config['OPENAPI_VERSION'] = openapi_version
-        if base_path is not None:
-            app.config['APPLICATION_ROOT'] = base_path
-        api = Api(app)
-        spec = api.spec.to_dict()
-
-        if openapi_version == '2.0':
-            assert spec['basePath'] == base_path or '/'
-        else:
-            assert 'basePath' not in spec
-
     @pytest.mark.parametrize(
         'parameter',
         [


### PR DESCRIPTION
This was the wrong thing to do.

I think it can only be set manually by the user.

See https://github.com/marshmallow-code/flask-smorest/pull/237#issuecomment-829011416.