### PR TITLE
Use click.echo() for spec output commands

### DIFF
--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -285,7 +285,7 @@ openapi_cli = flask.cli.AppGroup('openapi', help='OpenAPI commands.')
 def print_openapi_doc():
     """Print OpenAPI document."""
     api = current_app.extensions['flask-smorest']['ext_obj']
-    print(json.dumps(api.spec.to_dict(), indent=2))
+    click.echo(json.dumps(api.spec.to_dict(), indent=2))
 
 
 @openapi_cli.command('write')
@@ -293,4 +293,4 @@ def print_openapi_doc():
 def write_openapi_doc(output_file):
     """Write OpenAPI document to a file."""
     api = current_app.extensions['flask-smorest']['ext_obj']
-    output_file.write(json.dumps(api.spec.to_dict(), indent=2))
+    click.echo(json.dumps(api.spec.to_dict(), indent=2), file=output_file)


### PR DESCRIPTION
The `click.echo` function is a more proper way to output messages to stdout in `flask openapi print` command, as it states in [the docs](https://click.palletsprojects.com/en/8.0.x/api/#click.echo):

> Print a message and newline to stdout or a file. This should be used instead of print() because it provides better support for different data, files, and environments.

For consistency, this PR also change the `flask openapi write` command to use `click.echo` to write the file.