### PR TITLE
Fix rapidoc config when passing values with whitespaces

### DIFF
--- a/flask_smorest/spec/templates/rapidoc.html
+++ b/flask_smorest/spec/templates/rapidoc.html
@@ -9,7 +9,7 @@
     <rapi-doc
       spec-url = "{{ url_for('api-docs.openapi_json') }}"
       {% for key, val in rapidoc_config.items() -%}
-        {{key}} = {{val}}
+        {{key}} = "{{val}}"
       {% endfor -%}
     > </rapi-doc>
   </body>

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -230,7 +230,7 @@ class TestAPISpecServeDocs:
         Api(app)
         client = app.test_client()
         response_rapidoc = client.get("/")
-        assert "theme = dark" in response_rapidoc.get_data(True)
+        assert 'theme = "dark"' in response_rapidoc.get_data(True)
 
     @pytest.mark.parametrize('prefix', ('', '/'))
     @pytest.mark.parametrize('path', ('', '/'))


### PR DESCRIPTION
When passing config values, like `api-key-value="Bearer TOKEN"`, rapidoc will omit everything behind the whitespace.