### PR TITLE
Fix Blueprint registration with custom name (Flask 2.0.1)

### DIFF
--- a/flask_smorest/__init__.py
+++ b/flask_smorest/__init__.py
@@ -80,11 +80,12 @@ class Api(APISpecMixin, ErrorHandlerMixin):
 
         Must be called after app is initialized.
         """
+        blp_name = blp.name if "name" not in options else options["name"]
 
         self._app.register_blueprint(blp, **options)
 
         # Register views in API documentation for this resource
-        blp.register_views_in_doc(self, self._app, self.spec)
+        blp.register_views_in_doc(self, self._app, self.spec, name=blp_name)
 
         # Add tag relative to this resource to the global tag list
-        self.spec.tag({'name': blp.name, 'description': blp.description})
+        self.spec.tag({'name': blp_name, 'description': blp.description})

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -162,7 +162,7 @@ class Blueprint(
         # Store parameters doc info from route decorator
         endpoint_doc_info['parameters'] = parameters
 
-    def register_views_in_doc(self, api, app, spec):
+    def register_views_in_doc(self, api, app, spec, *, name):
         """Register views information in documentation
 
         If a schema in a parameter or a response appears in the spec
@@ -193,13 +193,13 @@ class Blueprint(
                     )
                 operation_doc.update(operation_doc_info['docstring'])
                 # Tag all operations with Blueprint name
-                operation_doc['tags'] = [self.name]
+                operation_doc['tags'] = [name]
                 # Complete doc with manual doc info
                 manual_doc = operation_doc_info.get('manual_doc', {})
                 doc[method_l] = deepupdate(operation_doc, manual_doc)
 
             # Thanks to self.route, there can only be one rule per endpoint
-            full_endpoint = '.'.join((self.name, endpoint))
+            full_endpoint = '.'.join((name, endpoint))
             rule = next(app.url_map.iter_rules(full_endpoint))
             spec.path(rule=rule, operations=doc, parameters=parameters)
 


### PR DESCRIPTION
Since Flask 2.0.1, a custom name can be passed when registering a Blueprint to override the Blueprint name.

This PR fixes that use case and ensures the docs are correct.

This also fixes a test that registers twice the same Blueprint with the same name, which is deprecated in Flask 2 and will be forbidden in 2.1.