### PR TITLE
Lazy register components (default responses, ETag and pagination headers)

### DIFF
--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -129,7 +129,6 @@ It contains the pagination information.
     #     'previous_page': 1, 'next_page': 3,
     # }
 
-The name of the header can be changed by overriding
-``PAGINATION_HEADER_FIELD_NAME`` class attribute of the
-:class:`Blueprint <Blueprint>` class. When setting this attribute to ``None``,
-no pagination header is added to the response.
+The name of the header can be changed by overriding ``PAGINATION_HEADER_NAME``
+class attribute of the :class:`Blueprint <Blueprint>` class. When setting this
+attribute to ``None``, no pagination header is added to the response.

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -131,7 +131,7 @@ class PaginationMixin:
 
     # Name of field to use for pagination metadata response header
     # Can be overridden. If None, no pagination header is returned.
-    PAGINATION_HEADER_FIELD_NAME = 'X-Pagination'
+    PAGINATION_HEADER_NAME = 'X-Pagination'
 
     # Global default pagination parameters
     # Can be overridden to provide custom defaults
@@ -197,7 +197,7 @@ class PaginationMixin:
                     result = pager(result, page_params=page_params).items
 
                 # Set pagination metadata in response
-                if self.PAGINATION_HEADER_FIELD_NAME is not None:
+                if self.PAGINATION_HEADER_NAME is not None:
                     if page_params.item_count is None:
                         warnings.warn(
                             'item_count not set in endpoint {}.'
@@ -257,7 +257,7 @@ class PaginationMixin:
         """
         if headers is None:
             headers = {}
-        headers[self.PAGINATION_HEADER_FIELD_NAME] = json.dumps(
+        headers[self.PAGINATION_HEADER_NAME] = json.dumps(
             self._make_pagination_metadata(
                 page_params.page,
                 page_params.page_size,
@@ -272,7 +272,7 @@ class PaginationMixin:
         Override this to document custom pagination metadata
         """
         resp_doc['headers'] = {
-            self.PAGINATION_HEADER_FIELD_NAME: {
+            self.PAGINATION_HEADER_NAME: {
                 'description': 'Pagination metadata',
                 'schema': PaginationMetadataSchema,
             }

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -124,6 +124,12 @@ class PaginationMetadataSchema(ma.Schema):
         ordered = True
 
 
+PAGINATION_HEADER = {
+    'description': 'Pagination metadata',
+    'schema': PaginationMetadataSchema,
+}
+
+
 class PaginationMixin:
     """Extend Blueprint to add Pagination feature"""
 
@@ -272,10 +278,9 @@ class PaginationMixin:
         Override this to document custom pagination metadata
         """
         resp_doc['headers'] = {
-            self.PAGINATION_HEADER_NAME: {
-                'description': 'Pagination metadata',
-                'schema': PaginationMetadataSchema,
-            }
+            self.PAGINATION_HEADER_NAME:
+            "PAGINATION" if spec.openapi_version.major >= 3
+            else PAGINATION_HEADER
         }
 
     def _prepare_pagination_doc(self, doc, doc_info, *, spec, **kwargs):

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -11,6 +11,7 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 from flask_smorest.exceptions import MissingAPIParameterError
 from flask_smorest.utils import prepare_response
 from flask_smorest import etag as fs_etag
+from flask_smorest import pagination as fs_pagination
 from .plugins import FlaskPlugin
 from .field_converters import uploadfield2properties
 from .constants import (
@@ -202,6 +203,9 @@ class APISpecMixin(DocBlueprintMixin):
         # Lazy register ETag headers
         self._register_etag_headers()
 
+        # Lazy register pagination header
+        self._register_pagination_header()
+
         # Register OpenAPI command group
         self._app.cli.add_command(openapi_cli)
 
@@ -309,6 +313,11 @@ class APISpecMixin(DocBlueprintMixin):
             "IF_MATCH", "header", fs_etag.IF_MATCH_HEADER, lazy=True)
         if self.spec.openapi_version.major >= 3:
             self.spec.components.header("ETAG", fs_etag.ETAG_HEADER, lazy=True)
+
+    def _register_pagination_header(self):
+        if self.spec.openapi_version.major >= 3:
+            self.spec.components.header(
+                "PAGINATION", fs_pagination.PAGINATION_HEADER, lazy=True)
 
 
 openapi_cli = flask.cli.AppGroup('openapi', help='OpenAPI commands.')

--- a/flask_smorest/spec/__init__.py
+++ b/flask_smorest/spec/__init__.py
@@ -10,6 +10,7 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 
 from flask_smorest.exceptions import MissingAPIParameterError
 from flask_smorest.utils import prepare_response
+from flask_smorest import etag as fs_etag
 from .plugins import FlaskPlugin
 from .field_converters import uploadfield2properties
 from .constants import (
@@ -198,6 +199,9 @@ class APISpecMixin(DocBlueprintMixin):
         # Lazy register default responses
         self._register_responses()
 
+        # Lazy register ETag headers
+        self._register_etag_headers()
+
         # Register OpenAPI command group
         self._app.cli.add_command(openapi_cli)
 
@@ -297,6 +301,14 @@ class APISpecMixin(DocBlueprintMixin):
         }
         prepare_response(response, self.spec, DEFAULT_RESPONSE_CONTENT_TYPE)
         self.spec.components.response('DEFAULT_ERROR', response, lazy=True)
+
+    def _register_etag_headers(self):
+        self.spec.components.parameter(
+            "IF_NONE_MATCH", "header", fs_etag.IF_NONE_MATCH_HEADER, lazy=True)
+        self.spec.components.parameter(
+            "IF_MATCH", "header", fs_etag.IF_MATCH_HEADER, lazy=True)
+        if self.spec.openapi_version.major >= 3:
+            self.spec.components.header("ETAG", fs_etag.ETAG_HEADER, lazy=True)
 
 
 openapi_cli = flask.cli.AppGroup('openapi', help='OpenAPI commands.')

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
         'flask>=2.0,<3',
         'marshmallow>=3.13.0,<4',
         'webargs>=8.0.0,<9',
-        'apispec>=5.0.0,<6',
+        'apispec>=5.1.0,<6',
     ],
 )

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -120,11 +120,11 @@ class TestPagination:
 
     @pytest.mark.parametrize('header_name', ('X-Dummy-Name', None))
     def test_pagination_custom_header_field_name(self, app, header_name):
-        """Test PAGINATION_HEADER_FIELD_NAME overriding"""
+        """Test PAGINATION_HEADER_NAME overriding"""
         api = Api(app)
 
         class CustomBlueprint(Blueprint):
-            PAGINATION_HEADER_FIELD_NAME = header_name
+            PAGINATION_HEADER_NAME = header_name
 
         blp = CustomBlueprint('test', __name__, url_prefix='/test')
 
@@ -153,7 +153,7 @@ class TestPagination:
         api = Api(app)
 
         class CustomBlueprint(Blueprint):
-            PAGINATION_HEADER_FIELD_NAME = 'X-Custom-Pagination-Header'
+            PAGINATION_HEADER_NAME = 'X-Custom-Pagination-Header'
 
         blp = CustomBlueprint('test', __name__, url_prefix='/test')
 
@@ -180,7 +180,7 @@ class TestPagination:
         api = Api(app)
 
         class CustomBlueprint(Blueprint):
-            PAGINATION_HEADER_FIELD_NAME = header_name
+            PAGINATION_HEADER_NAME = header_name
 
         blp = CustomBlueprint('test', __name__, url_prefix='/test')
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -148,8 +148,10 @@ class TestPagination:
             # Also check there is only one pagination header
             assert len(response.headers.getlist(header_name)) == 1
 
-    def test_pagination_header_documentation(self, app):
+    @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.2'))
+    def test_pagination_header_documentation(self, app, openapi_version):
         """Test pagination header is documented"""
+        app.config['OPENAPI_VERSION'] = openapi_version
         api = Api(app)
 
         class CustomBlueprint(Blueprint):
@@ -167,12 +169,19 @@ class TestPagination:
         spec = api.spec.to_dict()
         get = spec['paths']['/test/']['get']
         assert 'PaginationMetadata' in get_schemas(api.spec)
-        assert get['responses']['200']['headers'] == {
-            'X-Custom-Pagination-Header': {
-                'description': 'Pagination metadata',
-                'schema': {'$ref': '#/components/schemas/PaginationMetadata'},
+        if openapi_version == "2.0":
+            assert get['responses']['200']['headers'] == {
+                'X-Custom-Pagination-Header': {
+                    'description': 'Pagination metadata',
+                    'schema': {'$ref': '#/definitions/PaginationMetadata'},
+                }
             }
-        }
+        else:
+            assert get['responses']['200']['headers'] == {
+                'X-Custom-Pagination-Header': {
+                    '$ref': '#/components/headers/PAGINATION'
+                }
+            }
 
     @pytest.mark.parametrize('header_name', ('X-Pagination', None))
     def test_pagination_item_count_missing(self, app, header_name):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,5 +15,15 @@ def get_responses(spec):
     return spec.to_dict()["components"]["responses"]
 
 
+def get_parameters(spec):
+    if spec.openapi_version.major < 3:
+        return spec.to_dict()["parameters"]
+    return spec.to_dict()["components"]["parameters"]
+
+
+def get_headers(spec):
+    return spec.to_dict()["components"]["headers"]
+
+
 def build_ref(spec, component_type, obj):
     return build_reference(component_type, spec.openapi_version.major, obj)


### PR DESCRIPTION
Closes #236.

Remove @lindycoder's `ResponseReferencesPlugin` as it no longer useful.

Require apispec>=5.1.0

Also rename `PAGINATION_HEADER_FIELD_NAME` to `PAGINATION_HEADER_NAME`.