### PR TITLE
Add tags parameter to route/add_url_rule

### DIFF
--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -548,6 +548,28 @@ class TestBlueprint:
 
         assert tuple(spec["paths"]["/test/"].keys()) == ("get", "put")
 
+    def test_blueprint_route_tags(self, app):
+        """Check passing tags to route"""
+        blp = Blueprint('test', __name__, url_prefix='/test')
+
+        @blp.route('/test_1/', tags=["Tag 1", "Tag 2"])
+        def test_1():
+            pass
+
+        @blp.route('/test_2/')
+        def test_2():
+            pass
+
+        api = Api(app)
+        api.register_blueprint(blp)
+        spec = api.spec.to_dict()
+
+        assert (
+            spec["paths"]["/test/test_1/"]["get"]["tags"] ==
+            ["Tag 1", "Tag 2"]
+        )
+        assert spec["paths"]["/test/test_2/"]["get"]["tags"] == ["test", ]
+
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
     def test_blueprint_response_schema(self, app, openapi_version, schemas):
         """Check response schema is correctly documented.


### PR DESCRIPTION
By default, we use the name of the Blueprint so that resources are sorted by Blueprint in spec viewers (Swagger-UI,...).

But sometimes a user may wish to publish a sub-resource under another tag.

This change allows a user to specify tags explicitly.