### PR TITLE
Added new parameter in Route decorator 'hidden_from_api_spec';

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,3 +22,4 @@ Contributors (chronological)
 - Stephen Rosen `@sirosen <https://github.com/sirosen>`_
 - Grey Li `@greyli <https://github.com/greyli>`_
 - Tim Diekmann `@TimDiekmann <https://github.com/TimDiekmann>`_
+- 0x78f1935 `@0x78f1935 <https://github.com/0x78f1935>`_

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -99,6 +99,7 @@ class Blueprint(
         *,
         parameters=None,
         tags=None,
+        hidden_from_api_spec=False,
         **options,
     ):
         """Register url rule in application
@@ -116,6 +117,9 @@ class Blueprint(
             in this path, only used to document the resource.
         :param list tags: List of tags for the resource.
             If None, ``Blueprint`` name is used.
+        :param boolean hidden_from_api_spec: Don't document resource in API
+            spec file.
+            Default False.
         :param options: Options to be forwarded to the underlying
             :class:`werkzeug.routing.Rule <Rule>` object.
         """
@@ -139,10 +143,19 @@ class Blueprint(
 
         # Add URL rule in Flask and store endpoint documentation
         super().add_url_rule(rule, endpoint, func, **options)
-        self._store_endpoint_docs(
-            endpoint, view_func, parameters, tags, **options)
+        if not hidden_from_api_spec:
+            self._store_endpoint_docs(
+                endpoint, view_func, parameters, tags, **options)
 
-    def route(self, rule, *, parameters=None, tags=None, **options):
+    def route(
+            self,
+            rule,
+            *,
+            parameters=None,
+            tags=None,
+            hidden_from_api_spec=False,
+            **options
+            ):
         """Decorator to register view function in application and documentation
 
         Calls :meth:`add_url_rule <Blueprint.add_url_rule>`.
@@ -155,6 +168,7 @@ class Blueprint(
                 func,
                 parameters=parameters,
                 tags=tags,
+                hidden_from_api_spec=hidden_from_api_spec,
                 **options
             )
             return func

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -570,6 +570,24 @@ class TestBlueprint:
         )
         assert spec["paths"]["/test/test_2/"]["get"]["tags"] == ["test", ]
 
+    def test_blueprint_route_hidden_from_api_spec(self, app):
+        """Check passing hidden_from_api_spec to route"""
+        blp = Blueprint('test', __name__, url_prefix='/test')
+
+        @blp.route('/test_1/', hidden_from_api_spec=True)
+        def test_1():
+            pass
+
+        @blp.route('/test_2/')
+        def test_2():
+            pass
+
+        api = Api(app)
+        api.register_blueprint(blp)
+        spec = api.spec.to_dict()
+        assert "/test/test_1/" not in spec["paths"]
+        assert "/test/test_2/" in spec["paths"]
+
     @pytest.mark.parametrize('openapi_version', ['2.0', '3.0.2'])
     def test_blueprint_response_schema(self, app, openapi_version, schemas):
         """Check response schema is correctly documented.


### PR DESCRIPTION
* Added new parameter in Route decorator 'hidden_from_api_spec'
* Added related unittest
* Added missing required libraries for unittests in dev-requirements.txt
* Updated AUTHORS.rst

See https://github.com/marshmallow-code/flask-smorest/pull/276

I never squashed myself and i Kinda screwed up the previous pr.
Re-forked the original library and applied the changes.

@lafrech Thank you for taking the time for those changes!

On another note, I've found some alternatives for ReDoc which I would like to implement. I might create a new PR for this if you are oke with this. See https://stackoverflow.com/questions/36634281/list-of-swagger-ui-alternatives