### PR TITLE
Rework alt_response signature

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -150,6 +150,8 @@ Note that ``app.config`` overrides ``spec_kwargs``. The example above produces
 
     {"host": "example.com", "x-internal-id": "2"}
 
+.. _document-top-level-components:
+
 Document Top-level Components
 -----------------------------
 

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -69,9 +69,10 @@ which results in a ``HTTPException``, or if it returns a ``Response`` object
 which is returned as is.
 
 Those alternative responses can be documented using the
-:meth:`Blueprint.alt_response <Blueprint.alt_response>` decorator. Its
-signature is the same as ``response`` but its parameters are only used to
-document the response.
+:meth:`Blueprint.alt_response <Blueprint.alt_response>` decorator. This method
+can be passed a reference to a registered response component
+(see :ref:`document-top-level-components`) or elements to build the response
+documentation like :meth:`Blueprint.response <Blueprint.response>` does.
 
 A view function may only be decorated once with ``response`` but can be
 decorated multiple times with nested ``alt_response``.

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -127,8 +127,9 @@ class ResponseMixin:
     def alt_response(
         self,
         status_code,
-        schema_or_ref,
+        response=None,
         *,
+        schema=None,
         description=None,
         example=None,
         examples=None,
@@ -137,20 +138,28 @@ class ResponseMixin:
         """Decorator documenting an alternative response
 
         :param int|str|HTTPStatus status_code: HTTP status code.
-        :param schema_or_ref: Either a :class:`Schema <marshmallow.Schema>`
-            class or instance or a string error reference.
-            When passing a reference, arguments below are ignored.
+        :param str response: Reponse reference.
+        :param schema schema|str: :class:`Schema <marshmallow.Schema>`
+            class or instance or reference.
         :param str description: Description of the response (default: None).
         :param dict example: Example of response message.
         :param dict examples: Examples of response message.
         :param dict headers: Headers returned by the response.
+
+        This decorator allows the user to document an alternative response.
+        This can be an error managed with `abort` or any response that is not
+        the primary flow of the function documented by
+        :meth:`Blueprint.reponse <Blueprint.response>`.
+
+        When a response reference is passed as `response`, it is used as
+        description and the keyword arguments are ignored. Otherwise, a
+        description is built from the keyword arguments.
         """
-        # If a ref is passed
-        if isinstance(schema_or_ref, str):
-            resp_doc = schema_or_ref
-        # If a schema is passed
+        # Response ref is passed
+        if response is not None:
+            resp_doc = response
+        # Otherwise, build response description
         else:
-            schema = schema_or_ref
             if isinstance(schema, type):
                 schema = schema()
 

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -740,7 +740,10 @@ class TestBlueprint:
             )
 
     @pytest.mark.parametrize("openapi_version", ["2.0", "3.0.2"])
-    def test_blueprint_alt_response_schema(self, app, openapi_version, schemas):
+    @pytest.mark.parametrize("schema_type", ["object", "ref"])
+    def test_blueprint_alt_response_schema(
+        self, app, openapi_version, schemas, schema_type
+    ):
         """Check alternate response schema is correctly documented"""
         app.config["OPENAPI_VERSION"] = openapi_version
         api = Api(app)
@@ -758,30 +761,35 @@ class TestBlueprint:
             }
         }
 
+        if schema_type == "object":
+            schema = schemas.ClientErrorSchema
+        else:
+            schema = "ClientError"
+
         @blp.route("/")
-        @blp.alt_response(400, schemas.ClientErrorSchema)
+        @blp.alt_response(400, schema=schema)
         def func():
             pass
 
         @blp.route("/description")
-        @blp.alt_response(400, schemas.ClientErrorSchema, description="Client error")
+        @blp.alt_response(400, schema=schema, description="Client error")
         def func_with_description():
             pass
 
         @blp.route("/example")
-        @blp.alt_response(400, schemas.ClientErrorSchema, example=example)
+        @blp.alt_response(400, schema=schema, example=example)
         def func_with_example():
             pass
 
         if openapi_version == "3.0.2":
 
             @blp.route("/examples")
-            @blp.alt_response(400, schemas.ClientErrorSchema, examples=examples)
+            @blp.alt_response(400, schema=schema, examples=examples)
             def func_with_examples():
                 pass
 
         @blp.route("/headers")
-        @blp.alt_response(400, schemas.ClientErrorSchema, headers=headers)
+        @blp.alt_response(400, schema=schema, headers=headers)
         def func_with_headers():
             pass
 
@@ -844,7 +852,7 @@ class TestBlueprint:
         blp = Blueprint("test", "test", url_prefix="/test")
 
         @blp.route("/")
-        @blp.alt_response(400, schemas.ClientErrorSchema)
+        @blp.alt_response(400, schema=schemas.ClientErrorSchema)
         @blp.alt_response(404, "NotFoundErrorResponse")
         def func():
             pass
@@ -875,7 +883,7 @@ class TestBlueprint:
         client = app.test_client()
 
         @blp.route("/")
-        @blp.response(200, schemas.DocSchema)
+        @blp.response(200, schema=schemas.DocSchema)
         @blp.alt_response(400, "ClientErrorResponse")
         def func():
             return {"item_id": 12}


### PR DESCRIPTION
Closes #260.

*Breaking change: schema must be passed as kwarg, not positional.*

`alt_response` now expects either

- a response reference as string (response should be declared first as component)
- keyword arguments to build a response description for the docs

The signature now differs a bit more from `response` but it is better this way.

`schema` can now be a reference as string, or even `None` if none is needed (no content).

flask-smorest (lazily) declares a default response for all status codes, plus a default error response, so the user only needs to refer them with the right string (beware, no typo detection). Typically used for an "abort" response, because the error is registered with the error response format used by flask-smorest when aborting.

Examples:

```py
# Standard HTTP error by name
@blp.alt_response(404, "NOT_FOUND")

# Standard HTTP error by name, get name from http
@blp.alt_response(404, http.HTTPStatus(404).name)

# flask-smorest default error (name can be customized, see docs)
@blp.alt_response(422, "DEFAULT_ERROR")
```

