### PR TITLE
Allow alt_response to define a success response

### DIFF
--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -268,8 +268,8 @@ class EtagMixin:
                 responses[428] = http.HTTPStatus(428).name
                 doc.setdefault("parameters", []).append("IF_MATCH")
             if method_u in self.METHODS_ALLOWING_SET_ETAG:
-                success_status_code = doc_info.get("success_status_code")
-                if success_status_code is not None:
+                success_status_codes = doc_info.get("success_status_codes", [])
+                for success_status_code in success_status_codes:
                     doc["responses"][success_status_code].setdefault("headers", {})[
                         "ETag"
                     ] = (ETAG_HEADER if spec.openapi_version.major < 3 else "ETAG")

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -288,8 +288,8 @@ class PaginationMixin:
         if operation:
             doc.setdefault("parameters", []).append(operation["parameters"])
             doc.setdefault("responses", {}).update(operation["response"])
-            success_status_code = doc_info.get("success_status_code")
-            if success_status_code is not None:
+            success_status_codes = doc_info.get("success_status_codes", [])
+            for success_status_code in success_status_codes:
                 self._document_pagination_metadata(
                     spec, doc["responses"][success_status_code]
                 )

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -116,9 +116,9 @@ class ResponseMixin:
             wrapper._apidoc.setdefault("response", {}).setdefault("responses", {})[
                 status_code
             ] = resp_doc
-            # Indicate which code is the success status code
-            # Helps other decorators documenting success response
-            wrapper._apidoc["success_status_code"] = status_code
+            # Indicate this code is a success status code
+            # Helps other decorators documenting success responses
+            wrapper._apidoc.setdefault("success_status_codes", []).append(status_code)
 
             return wrapper
 

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -29,7 +29,7 @@ class ResponseMixin:
         description=None,
         example=None,
         examples=None,
-        headers=None
+        headers=None,
     ):
         """Decorator generating an endpoint response
 
@@ -133,7 +133,8 @@ class ResponseMixin:
         description=None,
         example=None,
         examples=None,
-        headers=None
+        headers=None,
+        success=False,
     ):
         """Decorator documenting an alternative response
 
@@ -188,7 +189,12 @@ class ResponseMixin:
             wrapper._apidoc.setdefault("response", {}).setdefault("responses", {})[
                 status_code
             ] = resp_doc
-
+            if success:
+                # Indicate this code is a success status code
+                # Helps other decorators documenting success responses
+                wrapper._apidoc.setdefault("success_status_codes", []).append(
+                    status_code
+                )
             return wrapper
 
         return decorator

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -518,27 +518,30 @@ class TestCustomExamples:
             def _prepare_response_doc(doc, doc_info, spec, **kwargs):
                 operation = doc_info.get("response", {})
                 if operation:
-                    success_code = doc_info["success_status_code"]
-                    response = operation.get("responses", {}).get(success_code)
-                    if response is not None:
-                        if "schema" in response:
-                            schema = response["schema"]
-                            response["schema"] = type(
-                                "Wrap" + schema.__class__.__name__,
-                                (ma.Schema,),
-                                {"data": ma.fields.Nested(schema)},
-                            )
-                            if "pagination" in doc_info:
+                    success_status_codes = doc_info.get("success_status_codes", [])
+                    for success_status_code in success_status_codes:
+                        response = operation.get("responses", {}).get(
+                            success_status_code
+                        )
+                        if response is not None:
+                            if "schema" in response:
                                 schema = response["schema"]
                                 response["schema"] = type(
-                                    "Pagination" + schema.__name__,
-                                    (schema,),
-                                    {
-                                        "pagination": ma.fields.Nested(
-                                            PaginationMetadataSchema
-                                        )
-                                    },
+                                    "Wrap" + schema.__class__.__name__,
+                                    (ma.Schema,),
+                                    {"data": ma.fields.Nested(schema)},
                                 )
+                                if "pagination" in doc_info:
+                                    schema = response["schema"]
+                                    response["schema"] = type(
+                                        "Pagination" + schema.__name__,
+                                        (schema,),
+                                        {
+                                            "pagination": ma.fields.Nested(
+                                                PaginationMetadataSchema
+                                            )
+                                        },
+                                    )
                 return super(WrapperBlueprint, WrapperBlueprint)._prepare_response_doc(
                     doc, doc_info, spec=spec, **kwargs
                 )


### PR DESCRIPTION
Closes #256.

This PR modifies the internals to allow multiple success responses. This, along with _apispec attribute should be made public API someday before 1.0 to allow users to craft auto-documenting custom decorators. Let's keep it internal for now.