### PR TITLE
Respect JSON_SORT_KEYS in _generate_etag

### DIFF
--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -141,9 +141,8 @@ class EtagMixin:
             raw_data = etag_schema.dump(etag_data)
         if extra_data:
             raw_data = (raw_data, extra_data)
-        # flask's json.dumps is needed here
-        # as vanilla json.dumps chokes on lazy_strings
-        data = json.dumps(raw_data, sort_keys=True)
+        # Use flask.json to respect app settings, specifically JSON_SORT_KEYS
+        data = json.dumps(raw_data)
         return hashlib.sha1(bytes(data, "utf-8")).hexdigest()
 
     def _check_precondition(self):

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -1,6 +1,5 @@
 """Test ETag feature"""
 
-from collections import OrderedDict
 import json
 import hashlib
 
@@ -128,56 +127,6 @@ def app_with_etag(request, collection, schemas, app):
 
 
 class TestEtag:
-    def test_etag_is_deterministic(self):
-        """Check etag computation is deterministic
-
-        _generate_etag should return the same value everytime the same
-        dictionary is passed. This is not obvious since dictionaries
-        are unordered by design. We check this by feeding it different
-        OrderedDict instances that are equivalent to the same dictionary.
-        """
-
-        blp = Blueprint("test", __name__)
-
-        data = OrderedDict(
-            [("a", 1), ("b", 2), ("c", OrderedDict([("a", 1), ("b", 2)]))]
-        )
-        etag = blp._generate_etag(data)
-
-        data_copies = [
-            OrderedDict(
-                [
-                    ("b", 2),
-                    ("a", 1),
-                    ("c", OrderedDict([("a", 1), ("b", 2)])),
-                ]
-            ),
-            OrderedDict(
-                [
-                    ("a", 1),
-                    ("b", 2),
-                    ("c", OrderedDict([("b", 2), ("a", 1)])),
-                ]
-            ),
-            OrderedDict(
-                [
-                    ("a", 1),
-                    ("c", OrderedDict([("a", 1), ("b", 2)])),
-                    ("b", 2),
-                ]
-            ),
-            OrderedDict(
-                [
-                    ("c", OrderedDict([("a", 1), ("b", 2)])),
-                    ("b", 2),
-                    ("a", 1),
-                ]
-            ),
-        ]
-
-        data_copies_etag = [blp._generate_etag(d) for d in data_copies]
-        assert all(e == etag for e in data_copies_etag)
-
     @pytest.mark.parametrize("extra_data", [None, {}, {"answer": 42}])
     def test_etag_generate_etag(self, schemas, extra_data):
         blp = Blueprint("test", __name__)


### PR DESCRIPTION
After all, there is no reason to force this here. Respecting the setting from Flask makes things more consistent with payload dump.

This change will affect users setting `JSON_SORT_KEYS` to `False` in that generated ETags will now differ if the order of the dict payload changes. This makes sense for a strong ETag.

There are more things I'd like to clean up in the ETag feature. We're doing too much in flask-smorest and we should rely more on Flask/Werkzeug. This is just an easy first step.

This could be considered a (minor) bug fix. And a (slightly) breaking change.