### PR TITLE
Drop PyPy from CI tests

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,6 @@ jobs:
         include:
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
-          - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py36,py37,py38,py39,pypy3
+envlist = lint,py36,py37,py38,py39
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
I copied this from another project (probably Flask or APIFlask) but never advertised support. pypy is not tested on marshmallow itself anyway.

Removing this reduces CI time, CI footprint, and spares me the need to update it when dropping EOL Python versions.

This can be reconsidered anytime.