### PR TITLE
Update error_handler.py to support description

### DIFF
--- a/flask_smorest/error_handler.py
+++ b/flask_smorest/error_handler.py
@@ -54,6 +54,12 @@ class ErrorHandlerMixin:
         """
         headers = {}
         payload = {"code": error.code, "status": error.name}
+        
+        # To cover the example:
+        # raise werkzeug.exceptions.BadRequest(description="<text>")
+        description = getattr(error, "description", None)
+        if description:
+            payload["description"] = error.description
 
         # Get additional info passed as kwargs when calling abort
         # data may not exist if HTTPException was raised without webargs abort


### PR DESCRIPTION
Currently raising a werkzeug HttpException exception, e.g. BadRequest(description="<text>"), results in a JSON object returned omitting the description field, versus the non-smorest scenario where the body of the text/html response includes the description.