### PR TITLE
Support nested blueprints in openapi spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,9 +97,6 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# Vscode settings
-.vscode
-
 # mkdocs documentation
 /site
 

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# Vscode settings
+.vscode
+
 # mkdocs documentation
 /site
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,3 +22,4 @@ Contributors (chronological)
 - Stephen Rosen `@sirosen <https://github.com/sirosen>`_
 - Grey Li `@greyli <https://github.com/greyli>`_
 - Tim Diekmann `@TimDiekmann <https://github.com/TimDiekmann>`_
+- Choudhury Noor `@Cnoor0171 <https://github.com/Cnoor0171>`_

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -169,6 +169,18 @@ Documentation components can be passed by accessing the internal apispec
         "Pet name", "query", {"description": "Item ID", "required": True}
     )
 
+.. _register-nested-blueprints:
+
+Register Nested Blueprints
+--------------------------
+
+:class:`Blueprint <Blueprint>` objects can be nested just like standard
+`flask nested blueprints`_.
+Endpoints from nested blueprints are automatically documented, but only the top
+level blueprints generate new "tag" entries in the OpenAPI spec.
+The tag name and description are taken from the top level blueprints. The nested blueprint
+metadata is ignored.
+
 Register Custom Fields
 ----------------------
 
@@ -373,6 +385,7 @@ Here's an example application configuration using all available UIs:
 .. _Swagger UI Configuration: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
 .. _RapiDoc: https://mrin9.github.io/RapiDoc/
 .. _RapiDoc API: https://mrin9.github.io/RapiDoc/api.html
+.. _flask nested blueprints: https://flask.palletsprojects.com/en/2.0.x/blueprints/#nesting-blueprints
 
 Write OpenAPI Documentation File
 --------------------------------

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -178,8 +178,7 @@ Register Nested Blueprints
 `flask nested blueprints`_.
 Endpoints from nested blueprints are automatically documented, but only the top
 level blueprints generate new "tag" entries in the OpenAPI spec.
-The tag name and description are taken from the top level blueprints. The nested blueprint
-metadata is ignored.
+The tag name and description are taken from the top level blueprints.
 
 Register Custom Fields
 ----------------------

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -27,8 +27,8 @@ Documentation process works in several steps:
   - Schema instances are replaced by their reference in the `schemas` section
     of the spec components.
 
-  - The ``register_blueprint`` method merges nested blueprint documentation into
-    the parent blueprint documentation.
+  - The ``Blueprint.register_blueprint`` method merges nested blueprint
+    documentation into the parent blueprint documentation.
 
   - Documentation is finalized using the information stored in
     ``Blueprint._docs``, with adaptations to parameters only known at init
@@ -168,11 +168,11 @@ class Blueprint(
     def register_blueprint(self, blueprint, **options):
         """Register a nested blueprint in application
 
-        Also stores doc info from the nested bluepint for later registration
+        Also stores doc info from the nested bluepint for later registration.
 
         Use this to register a nested :class:`Blueprint <Blueprint>`.
 
-        :param Blueprint blueprint: blueprint to register under this blueprint
+        :param Blueprint blueprint: Blueprint to register under this blueprint.
         :param options: Options to be forwarded to the underlying
             :meth:`flask.Blueprint.register_blueprint` method.
 

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -187,7 +187,6 @@ class Blueprint(
                 for endpoint_name, doc in blueprint._docs.items()
             }
         )
-        self._endpoints.extend(blueprint._endpoints)
 
         return super().register_blueprint(blueprint, **options)
 

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -27,6 +27,9 @@ Documentation process works in several steps:
   - Schema instances are replaced by their reference in the `schemas` section
     of the spec components.
 
+  - The ``register_blueprint`` method merges nested blueprint documentation into
+    the parent blueprint documentation.
+
   - Documentation is finalized using the information stored in
     ``Blueprint._docs``, with adaptations to parameters only known at init
     time, such as OAS version.
@@ -161,6 +164,32 @@ class Blueprint(
             return func
 
         return decorator
+
+    def register_blueprint(self, blueprint, **options):
+        """Register a nested blueprint in application
+
+        Also stores doc info from the nested bluepint for later registration
+
+        Use this to register a nested :class:`Blueprint <Blueprint>`.
+
+        :param Blueprint blueprint: blueprint to register under this blueprint
+        :param options: Options to be forwarded to the underlying
+            :meth:`flask.Blueprint.register_blueprint` method.
+
+        See :ref:`register-nested-blueprints`.
+        """
+        blp_name = options.get("name", blueprint.name)
+
+        # Inherit all endpoints
+        self._docs.update(
+            {
+                ".".join((blp_name, endpoint_name)): doc
+                for endpoint_name, doc in blueprint._docs.items()
+            }
+        )
+        self._endpoints.extend(blueprint._endpoints)
+
+        return super().register_blueprint(blueprint, **options)
 
     def _store_endpoint_docs(self, endpoint, obj, parameters, tags, **options):
         """Store view or function doc info"""


### PR DESCRIPTION
Closes https://github.com/marshmallow-code/flask-smorest/issues/261

Adds support for generating openapi spec for nested blueprints.

Only the top-level blueprints generate new "tag" sections, but all the endpoints, their arguments and responses are documented.

<details>
  <summary>Example code</summary>

```python
from flask import Flask
from flask.views import MethodView
import marshmallow as ma
from flask_smorest import Api, Blueprint, abort


app = Flask(__name__)
app.config["API_TITLE"] = "My API"
app.config["API_VERSION"] = "v1"
app.config["OPENAPI_VERSION"] = "3.0.2"
app.config["OPENAPI_URL_PREFIX"] = "/docs"
app.config["OPENAPI_SWAGGER_UI_PATH"] = "/swagger-ui"
app.config["OPENAPI_SWAGGER_UI_URL"] = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.24.2/"
api = Api(app)

class PetSchema(ma.Schema):
    id = ma.fields.Int(dump_only=True)
    name = ma.fields.String()

class PetQueryArgsSchema(ma.Schema):
    name = ma.fields.String()

class CattleSchema(ma.Schema):
    id = ma.fields.Int(dump_only=True)
    name = ma.fields.String()

class CattleQueryArgsSchema(ma.Schema):
    name = ma.fields.String()

par_blp = Blueprint("animals", "animals", url_prefix="/animals", description="Operations on animals")
child_1_blp = Blueprint("pets", "pets", url_prefix="/pets", description="Operations on pets")
child_2_blp = Blueprint("cattle", "cattle", url_prefix="/cattle", description="Operations on cattle")

@child_1_blp.route("/")
class Pets(MethodView):
    @child_1_blp.arguments(PetQueryArgsSchema, location="query")
    @child_1_blp.response(200, PetSchema(many=True))
    def get(self, args):
        """List pets"""

    @child_1_blp.arguments(PetSchema)
    @child_1_blp.response(201, PetSchema)
    def post(self, new_data):
        """Add a new pet"""

@child_2_blp.route("/")
class Cattle(MethodView):
    @child_2_blp.arguments(CattleQueryArgsSchema, location="query")
    @child_2_blp.response(200, CattleSchema(many=True))
    def get(self, args):
        """List Cattle"""

    @child_2_blp.arguments(CattleSchema)
    @child_2_blp.response(201, CattleSchema)
    def post(self, new_data):
        """Add a new cattle"""

par_blp.register_blueprint(child_1_blp)
par_blp.register_blueprint(child_2_blp)
api.register_blueprint(par_blp)
```
</details>

<details>
  <summary>Generate this</summary>
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/33206267/160311868-ab65c855-c227-449f-8094-3cfb1e0a7221.png">

</details>