### PR TITLE
Fix: Flask 2.2 'MethodViewType' Removal

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,4 +23,5 @@ Contributors (chronological)
 - Grey Li `@greyli <https://github.com/greyli>`_
 - Tim Diekmann `@TimDiekmann <https://github.com/TimDiekmann>`_
 - Choudhury Noor `@Cnoor0171 <https://github.com/Cnoor0171>`_
-- Dmitry Erlikh `@derlikh-smart <https://github.com/derlikh-smart>` _
+- Dmitry Erlikh `@derlikh-smart <https://github.com/derlikh-smart>`_
+- 0x78f1935 `@0x78f1935 <https://github.com/0x78f1935>`_

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -43,7 +43,7 @@ from functools import wraps
 from copy import deepcopy
 
 from flask import Blueprint as FlaskBlueprint
-from flask.views import MethodViewType
+from flask.views import MethodView
 
 from .utils import deepupdate, load_info_from_docstring
 from .arguments import ArgumentsMixin
@@ -141,7 +141,7 @@ class Blueprint(
             endpoint = f"{endpoint}_{len(self._endpoints)}"
         self._endpoints.append(endpoint)
 
-        if isinstance(view_func, MethodViewType):
+        if isinstance(view_func, type(MethodView)):
             func = view_func.as_view(endpoint)
         else:
             func = view_func
@@ -211,7 +211,7 @@ class Blueprint(
             endpoint_doc_info[method.lower()] = doc
 
         # MethodView (class)
-        if isinstance(obj, MethodViewType):
+        if isinstance(obj, type(MethodView)):
             for method in self.HTTP_METHODS:
                 if method in obj.methods:
                     if "methods" not in options or method in options["methods"]:


### PR DESCRIPTION
Fixes: https://github.com/marshmallow-code/flask-smorest/issues/384

```
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/development/development/tests/dist/webserver.py", line 9, in <module>
    from backend import Webserver
  File "/var/lib/jenkins/workspace/development/development/tests/dist/backend/__init__.py", line 15, in <module>
    from backend.extensions import init_app as _init_extensions
  File "/var/lib/jenkins/workspace/development/development/tests/dist/backend/extensions/__init__.py", line 9, in <module>
    from flask_smorest import Api  # noqa: E402
  File "/var/lib/jenkins/workspace/development/.pyenv-python3/lib/python3.9/site-packages/flask_smorest/__init__.py", line 6, in <module>
    from .blueprint import Blueprint  # noqa
  File "/var/lib/jenkins/workspace/development/.pyenv-python3/lib/python3.9/site-packages/flask_smorest/blueprint.py", line 46, in <module>
    from flask.views import MethodViewType
ImportError: cannot import name 'MethodViewType' from 'flask.views'
```

Same issue flask_apispec [has](https://stackoverflow.com/questions/73221330/attributeerror-module-flask-views-has-no-attribute-methodviewtype)
Fix inspired by [this](https://github.com/jmcarp/flask-apispec/pull/238/files) topic.
Might fix https://github.com/marshmallow-code/flask-smorest/pull/386 PR too.
