### PR TITLE
Use json rather than flask.json to generate ETag

### DIFF
--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -2,13 +2,14 @@
 
 from functools import wraps
 from copy import deepcopy
+import json
 import http
 import warnings
 
 import hashlib
 
 from marshmallow import Schema
-from flask import request, current_app, json
+from flask import request, current_app
 
 from .exceptions import PreconditionRequired, PreconditionFailed, NotModified
 from .utils import deepupdate, get_appcontext
@@ -126,7 +127,7 @@ class EtagMixin:
     def _generate_etag(etag_data, etag_schema=None, extra_data=None):
         """Generate an ETag from data
 
-        etag_data: Data to use to compute ETag
+        etag_data: Data to use to compute ETag (must be json serializable)
         etag_schema: Schema to dump data with before hashing
         extra_data: Extra data to add before hashing
 
@@ -141,8 +142,7 @@ class EtagMixin:
             raw_data = etag_schema.dump(etag_data)
         if extra_data:
             raw_data = (raw_data, extra_data)
-        # Use flask.json to respect app settings, specifically JSON_SORT_KEYS
-        data = json.dumps(raw_data)
+        data = json.dumps(raw_data, sort_keys=True)
         return hashlib.sha1(bytes(data, "utf-8")).hexdigest()
 
     def _check_precondition(self):

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -162,6 +162,12 @@ class TestEtag:
             ).hexdigest()
         )
 
+    def test_etag_generate_etag_order_insensitive(self):
+        blp = Blueprint("test", __name__)
+        data_1 = {"a": 1, "b": 2}
+        data_2 = {"b": 2, "a": 1}
+        assert blp._generate_etag(data_1) == blp._generate_etag(data_2)
+
     @pytest.mark.parametrize("method", HTTP_METHODS)
     def test_etag_check_precondition(self, app, method):
         blp = Blueprint("test", __name__)


### PR DESCRIPTION
Historically, we used flask.json because it serializes lazy strings but this should not be the responsibility of this framework.

Then, we decided not to force `sort_keys` for consistency with the way flask dumps the payload (#305). But there is no reason to do that for the "explicit ETag" (arbitrary data) case. And even if the app doesn't sort keys, doing it for ETag computation makes sense.

It is not easy to provide a one-size-fits-all solution. User is free to override `_generate_etag` for specific cases (specific json serializer, sort_keys=False,...).

Things can probably be improved in a wider ETag rework. Meanwhile, this change simplifies the code and fixes compatibility with Flask 2.2+ without breaking compatibility with Flask <2.2.

