### PR TITLE
Rework ETag: remove "ETag computed with API response data using another schema", allow decorating MethodView

### DIFF
--- a/docs/etag.rst
+++ b/docs/etag.rst
@@ -35,16 +35,15 @@ The :class:`Schema <marshmallow.Schema>` must be provided explicitly, even
 though it is the same as the response schema.
 
 .. code-block:: python
-    :emphasize-lines: 3, 8, 17, 22, 28, 32, 37
+    :emphasize-lines: 2,15,26,34
 
     @blp.route("/")
+    @blp.etag
     class Pet(MethodView):
-        @blp.etag
         @blp.response(200, PetSchema(many=True))
         def get(self):
             return Pet.get()
 
-        @blp.etag
         @blp.arguments(PetSchema)
         @blp.response(201, PetSchema)
         def post(self, new_data):
@@ -52,13 +51,12 @@ though it is the same as the response schema.
 
 
     @blp.route("/<pet_id>")
+    @blp.etag
     class PetById(MethodView):
-        @blp.etag
         @blp.response(200, PetSchema)
         def get(self, pet_id):
             return Pet.get_by_id(pet_id)
 
-        @blp.etag
         @blp.arguments(PetSchema)
         @blp.response(200, PetSchema)
         def put(self, update_data, pet_id):
@@ -68,7 +66,6 @@ though it is the same as the response schema.
             pet.update(update_data)
             return pet
 
-        @blp.etag
         @blp.response(204)
         def delete(self, pet_id):
             pet = Pet.get_by_id(pet_id)
@@ -87,11 +84,11 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
 :meth:`check_etag <Blueprint.check_etag>`.
 
 .. code-block:: python
-    :emphasize-lines: 3,8,11,16,22,26,29,35,38,41,46
+    :emphasize-lines: 2,8,15,20,25,33,36,43
 
     @blp.route("/")
+    @blp.etag
     class Pet(MethodView):
-        @blp.etag
         @blp.response(200, PetSchema(many=True))
         def get(self):
             pets = Pet.get()
@@ -99,7 +96,6 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
             blp.set_etag([pet.update_time for pet in pets])
             return pets
 
-        @blp.etag
         @blp.arguments(PetSchema)
         @blp.response(201, PetSchema)
         def post(self, new_data):
@@ -109,15 +105,14 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
 
 
     @blp.route("/<pet_id>")
+    @blp.etag
     class PetById(MethodView):
-        @blp.etag
         @blp.response(200, PetSchema)
         def get(self, pet_id):
             # Compute ETag using arbitrary data
             blp.set_etag(new_data["update_time"])
             return Pet.get_by_id(pet_id)
 
-        @blp.etag
         @blp.arguments(PetSchema)
         @blp.response(200, PetSchema)
         def put(self, update_data, pet_id):
@@ -129,7 +124,6 @@ to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
             blp.set_etag(new_data["update_time"])
             return pet
 
-        @blp.etag
         @blp.response(204)
         def delete(self, pet_id):
             pet = Pet.get_by_id(pet_id)

--- a/docs/etag.rst
+++ b/docs/etag.rst
@@ -35,7 +35,7 @@ The :class:`Schema <marshmallow.Schema>` must be provided explicitly, even
 though it is the same as the response schema.
 
 .. code-block:: python
-    :emphasize-lines: 28,37
+    :emphasize-lines: 3, 8, 17, 22, 28, 32, 37
 
     @blp.route("/")
     class Pet(MethodView):
@@ -76,59 +76,6 @@ though it is the same as the response schema.
             blp.check_etag(pet, PetSchema)
             Pet.delete(pet_id)
 
-ETag Computed with API Response Data Using Another Schema
----------------------------------------------------------
-
-Sometimes, it is not possible to use the data returned by the view function as
-ETag data because it contains extra information that is irrelevant, like
-HATEOAS information, for instance.
-
-In this case, a specific ETag schema should be provided to
-:meth:`Blueprint.etag <Blueprint.etag>`. Then, it does not need to be passed to
-:meth:`check_etag <Blueprint.check_etag>`.
-
-.. code-block:: python
-    :emphasize-lines: 3,8,17,22,28,32,37
-
-    @blp.route("/")
-    class Pet(MethodView):
-        @blp.etag(PetEtagSchema(many=True))
-        @blp.response(200, PetSchema(many=True))
-        def get(self):
-            return Pet.get()
-
-        @blp.etag(PetEtagSchema)
-        @blp.arguments(PetSchema)
-        @blp.response(201, PetSchema)
-        def post(self, new_pet):
-            return Pet.create(**new_data)
-
-
-    @blp.route("/<int:pet_id>")
-    class PetById(MethodView):
-        @blp.etag(PetEtagSchema)
-        @blp.response(200, PetSchema)
-        def get(self, pet_id):
-            return Pet.get_by_id(pet_id)
-
-        @blp.etag(PetEtagSchema)
-        @blp.arguments(PetSchema)
-        @blp.response(200, PetSchema)
-        def put(self, new_pet, pet_id):
-            pet = Pet.get_by_id(pet_id)
-            # Check ETag is a manual action and schema must be provided
-            blp.check_etag(pet)
-            pet.update(update_data)
-            return pet
-
-        @blp.etag(PetEtagSchema)
-        @blp.response(204)
-        def delete(self, pet_id):
-            pet = self._get_pet(pet_id)
-            # Check ETag is a manual action, ETag schema is used
-            blp.check_etag(pet)
-            Pet.delete(pet_id)
-
 ETag Computed on Arbitrary Data
 -------------------------------
 
@@ -137,8 +84,7 @@ The ETag can also be computed from arbitrary data by calling
 
 The example below illustrates this with no ETag schema, but it is also possible
 to pass an ETag schema to :meth:`set_etag <Blueprint.set_etag>` and
-:meth:`check_etag <Blueprint.check_etag>` or equivalently to
-:meth:`Blueprint.etag <Blueprint.etag>`.
+:meth:`check_etag <Blueprint.check_etag>`.
 
 .. code-block:: python
     :emphasize-lines: 3,8,11,16,22,26,29,35,38,41,46

--- a/flask_smorest/blueprint.py
+++ b/flask_smorest/blueprint.py
@@ -305,3 +305,17 @@ class Blueprint(
             return wrapper
 
         return decorator
+
+    def _decorate_view_func_or_method_view(self, decorator, obj):
+        """Apply decorator to view func or MethodView HTTP methods"""
+
+        # Decorating a MethodView decorates all HTTP methods
+        if isinstance(obj, type(MethodView)):
+            for method in self.HTTP_METHODS:
+                if method in obj.methods:
+                    method_l = method.lower()
+                    func = getattr(obj, method_l)
+                    setattr(obj, method_l, decorator(func))
+            return obj
+
+        return decorator(obj)

--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -11,7 +11,7 @@ import hashlib
 from flask import request, current_app
 
 from .exceptions import PreconditionRequired, PreconditionFailed, NotModified
-from .utils import deepupdate, get_appcontext
+from .utils import deepupdate, resolve_schema_instance, get_appcontext
 
 
 IF_NONE_MATCH_HEADER = {
@@ -140,9 +140,7 @@ class EtagMixin:
             warnings.warn(f"ETag cannot be checked on {request.method} request.")
         if _is_etag_enabled():
             if etag_schema is not None:
-                if isinstance(etag_schema, type):
-                    etag_schema = etag_schema()
-                etag_data = etag_schema.dump(etag_data)
+                etag_data = resolve_schema_instance(etag_schema).dump(etag_data)
             new_etag = self._generate_etag(etag_data)
             _get_etag_ctx()["etag_checked"] = True
             if new_etag not in request.if_match:
@@ -192,9 +190,7 @@ class EtagMixin:
             warnings.warn(f"ETag cannot be set on {request.method} request.")
         if _is_etag_enabled():
             if etag_schema is not None:
-                if isinstance(etag_schema, type):
-                    etag_schema = etag_schema()
-                etag_data = etag_schema.dump(etag_data)
+                etag_data = resolve_schema_instance(etag_schema).dump(etag_data)
             new_etag = self._generate_etag(etag_data)
             self._check_not_modified(new_etag)
             # Store ETag in AppContext to add it to response headers later on

--- a/flask_smorest/etag.py
+++ b/flask_smorest/etag.py
@@ -9,7 +9,6 @@ import warnings
 import hashlib
 
 from flask import request, current_app
-from flask.views import MethodView
 
 from .exceptions import PreconditionRequired, PreconditionFailed, NotModified
 from .utils import deepupdate, resolve_schema_instance, get_appcontext
@@ -98,16 +97,7 @@ class EtagMixin:
 
             return wrapper
 
-        # Decorating a MethodView decorates all HTTP methods
-        if isinstance(obj, type(MethodView)):
-            for method in self.HTTP_METHODS:
-                if method in obj.methods:
-                    method_l = method.lower()
-                    func = getattr(obj, method_l)
-                    setattr(obj, method_l, decorator(func))
-            return obj
-
-        return decorator(obj)
+        return self._decorate_view_func_or_method_view(decorator, obj)
 
     @staticmethod
     def _generate_etag(etag_data, extra_data=None):

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -105,7 +105,6 @@ class ResponseMixin:
 
                 # Store result in appcontext (may be used for ETag computation)
                 appcontext = get_appcontext()
-                appcontext["result_raw"] = result_raw
                 appcontext["result_dump"] = result_dump
 
                 # Build response

--- a/flask_smorest/response.py
+++ b/flask_smorest/response.py
@@ -11,6 +11,7 @@ from flask import jsonify
 from .utils import (
     deepupdate,
     remove_none,
+    resolve_schema_instance,
     get_appcontext,
     prepare_response,
     unpack_tuple_response,
@@ -63,8 +64,7 @@ class ResponseMixin:
 
         See :doc:`Response <response>`.
         """
-        if isinstance(schema, type):
-            schema = schema()
+        schema = resolve_schema_instance(schema)
 
         # Document response (schema, description,...) in the API doc
         doc_schema = self._make_doc_response_schema(schema)
@@ -171,8 +171,7 @@ class ResponseMixin:
             resp_doc = response
         # Otherwise, build response description
         else:
-            if isinstance(schema, type):
-                schema = schema()
+            schema = resolve_schema_instance(schema)
 
             # Document response (schema, description,...) in the API doc
             doc_schema = self._make_doc_response_schema(schema)

--- a/flask_smorest/utils.py
+++ b/flask_smorest/utils.py
@@ -28,6 +28,15 @@ def remove_none(mapping):
     return {k: v for k, v in mapping.items() if v is not None}
 
 
+def resolve_schema_instance(schema):
+    """Return schema instance for given schema (instance or class).
+
+    :param type|Schema schema: marshmallow.Schema instance or class
+    :return: schema instance of given schema
+    """
+    return schema() if isinstance(schema, type) else schema
+
+
 def get_appcontext():
     """Get extension section in flask g"""
     return g.setdefault("_flask_smorest", {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,9 +66,6 @@ def schemas():
         item_id = ma.fields.Int(dump_only=True)
         field = ma.fields.Int(attribute="db_field")
 
-    class DocEtagSchema(CounterSchema):
-        field = ma.fields.Int(attribute="db_field")
-
     class QueryArgsSchema(ma.Schema):
         class Meta:
             ordered = True
@@ -81,6 +78,6 @@ def schemas():
         error_id = ma.fields.Str()
         text = ma.fields.Str()
 
-    return namedtuple(
-        "Model", ("DocSchema", "DocEtagSchema", "QueryArgsSchema", "ClientErrorSchema")
-    )(DocSchema, DocEtagSchema, QueryArgsSchema, ClientErrorSchema)
+    return namedtuple("Model", ("DocSchema", "QueryArgsSchema", "ClientErrorSchema"))(
+        DocSchema, QueryArgsSchema, ClientErrorSchema
+    )

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -34,6 +34,7 @@ def app_with_etag(request, collection, schemas, app):
 
     if as_method_view:
 
+        # Decorate each function
         @blp.route("/")
         class Resource(MethodView):
             @blp.etag
@@ -47,7 +48,9 @@ def app_with_etag(request, collection, schemas, app):
             def post(self, new_item):
                 return collection.post(new_item)
 
+        # Better: decorate the whole MethodView
         @blp.route("/<int:item_id>")
+        @blp.etag
         class ResourceById(MethodView):
             def _get_item(self, item_id):
                 try:
@@ -55,12 +58,10 @@ def app_with_etag(request, collection, schemas, app):
                 except ItemNotFound:
                     abort(404)
 
-            @blp.etag
             @blp.response(200, DocSchema)
             def get(self, item_id):
                 return self._get_item(item_id)
 
-            @blp.etag
             @blp.arguments(DocSchema)
             @blp.response(200, DocSchema)
             def put(self, new_item, item_id):
@@ -68,7 +69,6 @@ def app_with_etag(request, collection, schemas, app):
                 blp.check_etag(item, DocSchema)
                 return collection.put(item_id, new_item)
 
-            @blp.etag
             @blp.response(204)
             def delete(self, item_id):
                 item = self._get_item(item_id)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -73,69 +73,6 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
     return blp
 
 
-def implicit_data_explicit_schema_etag_blueprint(collection, schemas):
-    """Blueprint with implicit ETag computation, explicit schema
-
-    ETag computed automatically with specific ETag schema
-    """
-
-    DocSchema = schemas.DocSchema
-    DocEtagSchema = schemas.DocEtagSchema
-
-    blp = Blueprint("test", __name__, url_prefix="/test")
-
-    @blp.route("/")
-    class Resource(MethodView):
-        @blp.etag(DocEtagSchema(many=True))
-        @blp.response(200, DocSchema(many=True))
-        @blp.paginate()
-        def get(self, pagination_parameters):
-            pagination_parameters.item_count = len(collection.items)
-            return collection.items[
-                pagination_parameters.first_item : pagination_parameters.last_item + 1
-            ]
-
-        @blp.etag(DocEtagSchema)
-        @blp.arguments(DocSchema)
-        @blp.response(201, DocSchema)
-        def post(self, new_item):
-            return collection.post(new_item)
-
-    @blp.route("/<int:item_id>")
-    class ResourceById(MethodView):
-        def _get_item(self, item_id):
-            try:
-                return collection.get_by_id(item_id)
-            except ItemNotFound:
-                abort(404)
-
-        @blp.etag(DocEtagSchema)
-        @blp.response(200, DocSchema)
-        def get(self, item_id):
-            item = self._get_item(item_id)
-            return item
-
-        @blp.etag(DocEtagSchema)
-        @blp.arguments(DocSchema)
-        @blp.response(200, DocSchema)
-        def put(self, new_item, item_id):
-            item = self._get_item(item_id)
-            # Check ETag is a manual action, ETag schema is used
-            blp.check_etag(item)
-            new_item = collection.put(item_id, new_item)
-            return new_item
-
-        @blp.etag(DocEtagSchema)
-        @blp.response(204)
-        def delete(self, item_id):
-            item = self._get_item(item_id)
-            # Check ETag is a manual action, ETag schema is used
-            blp.check_etag(item)
-            collection.delete(item_id)
-
-    return blp
-
-
 def explicit_data_no_schema_etag_blueprint(collection, schemas):
     """Blueprint with explicit ETag computation, no schema
 
@@ -210,20 +147,20 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
 
 @pytest.fixture(
     params=[
-        (implicit_data_and_schema_etag_blueprint, "Schema"),
-        (implicit_data_explicit_schema_etag_blueprint, "ETag schema"),
-        (explicit_data_no_schema_etag_blueprint, "No schema"),
+        (implicit_data_and_schema_etag_blueprint, True),
+        (explicit_data_no_schema_etag_blueprint, False),
     ]
 )
 def blueprint_fixture(request, collection, schemas):
     blp_factory = request.param[0]
-    return blp_factory(collection, schemas), request.param[1]
+    etag_schema = request.param[1]
+    return blp_factory(collection, schemas), etag_schema
 
 
 class TestFullExample:
     def test_examples(self, app, blueprint_fixture, schemas):
 
-        blueprint, bp_schema = blueprint_fixture
+        blueprint, etag_schema = blueprint_fixture
 
         api = Api(app)
         api.register_blueprint(blueprint)
@@ -231,22 +168,16 @@ class TestFullExample:
         client = app.test_client()
 
         @contextmanager
-        def assert_counters(
-            schema_load, schema_dump, etag_schema_load, etag_schema_dump
-        ):
-            """Check number of calls to dump/load methods of schemas"""
+        def assert_counters(schema_load, schema_dump):
+            """Check number of calls to dump/load methods of schema"""
             schemas.DocSchema.reset_load_count()
             schemas.DocSchema.reset_dump_count()
-            schemas.DocEtagSchema.reset_load_count()
-            schemas.DocEtagSchema.reset_dump_count()
             yield
             assert schemas.DocSchema.load_count == schema_load
             assert schemas.DocSchema.dump_count == schema_dump
-            assert schemas.DocEtagSchema.load_count == etag_schema_load
-            assert schemas.DocEtagSchema.dump_count == etag_schema_dump
 
         # GET collection without ETag: OK
-        with assert_counters(0, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(0, 1):
             response = client.get("/test/")
             assert response.status_code == 200
             list_etag = response.headers["ETag"]
@@ -257,13 +188,13 @@ class TestFullExample:
             }
 
         # GET collection with correct ETag: Not modified
-        with assert_counters(0, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(0, 1):
             response = client.get("/test/", headers={"If-None-Match": list_etag})
         assert response.status_code == 304
 
         # POST item_1
         item_1_data = {"field": 0}
-        with assert_counters(1, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(1, 1):
             response = client.post(
                 "/test/", data=json.dumps(item_1_data), content_type="application/json"
             )
@@ -271,7 +202,7 @@ class TestFullExample:
         item_1_id = response.json["item_id"]
 
         # GET collection with wrong/outdated ETag: OK
-        with assert_counters(0, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(0, 1):
             response = client.get("/test/", headers={"If-None-Match": list_etag})
         assert response.status_code == 200
         list_etag = response.headers["ETag"]
@@ -286,18 +217,13 @@ class TestFullExample:
         }
 
         # GET by ID without ETag: OK
-        with assert_counters(0, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(0, 1):
             response = client.get(f"/test/{item_1_id}")
         assert response.status_code == 200
         item_etag = response.headers["ETag"]
 
         # GET by ID with correct ETag: Not modified
-        with assert_counters(
-            0,
-            0 if bp_schema == "No schema" else 1,
-            0,
-            1 if bp_schema == "ETag schema" else 0,
-        ):
+        with assert_counters(0, 1 if etag_schema else 0):
             response = client.get(
                 f"/test/{item_1_id}", headers={"If-None-Match": item_etag}
             )
@@ -305,7 +231,7 @@ class TestFullExample:
 
         # PUT without ETag: Precondition required error
         item_1_data["field"] = 1
-        with assert_counters(0, 0, 0, 0):
+        with assert_counters(0, 0):
             response = client.put(
                 f"/test/{item_1_id}",
                 data=json.dumps(item_1_data),
@@ -314,12 +240,7 @@ class TestFullExample:
         assert response.status_code == 428
 
         # PUT with correct ETag: OK
-        with assert_counters(
-            1,
-            2 if bp_schema == "Schema" else 1,
-            0,
-            2 if bp_schema == "ETag schema" else 0,
-        ):
+        with assert_counters(1, 2 if etag_schema else 1):
             response = client.put(
                 f"/test/{item_1_id}",
                 data=json.dumps(item_1_data),
@@ -331,12 +252,7 @@ class TestFullExample:
 
         # PUT with wrong/outdated ETag: Precondition failed error
         item_1_data["field"] = 2
-        with assert_counters(
-            1,
-            1 if bp_schema == "Schema" else 0,
-            0,
-            1 if bp_schema == "ETag schema" else 0,
-        ):
+        with assert_counters(1, 1 if etag_schema else 0):
             response = client.put(
                 f"/test/{item_1_id}",
                 data=json.dumps(item_1_data),
@@ -346,14 +262,14 @@ class TestFullExample:
         assert response.status_code == 412
 
         # GET by ID with wrong/outdated ETag: OK
-        with assert_counters(0, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(0, 1):
             response = client.get(
                 f"/test/{item_1_id}", headers={"If-None-Match": item_etag}
             )
         assert response.status_code == 200
 
         # GET collection with pagination set to 1 element per page
-        with assert_counters(0, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(0, 1):
             response = client.get(
                 "/test/",
                 headers={"If-None-Match": list_etag},
@@ -373,7 +289,7 @@ class TestFullExample:
 
         # POST item_2
         item_2_data = {"field": 1}
-        with assert_counters(1, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(1, 1):
             response = client.post(
                 "/test/", data=json.dumps(item_2_data), content_type="application/json"
             )
@@ -382,7 +298,7 @@ class TestFullExample:
         # GET collection with pagination set to 1 element per page
         # Content is the same (item_1) but pagination metadata has changed
         # so we don't get a 304 and the data is returned again
-        with assert_counters(0, 1, 0, 1 if bp_schema == "ETag schema" else 0):
+        with assert_counters(0, 1):
             response = client.get(
                 "/test/",
                 headers={"If-None-Match": list_etag},
@@ -402,29 +318,19 @@ class TestFullExample:
         }
 
         # DELETE without ETag: Precondition required error
-        with assert_counters(0, 0, 0, 0):
+        with assert_counters(0, 0):
             response = client.delete(f"/test/{item_1_id}")
         assert response.status_code == 428
 
         # DELETE with wrong/outdated ETag: Precondition failed error
-        with assert_counters(
-            0,
-            1 if bp_schema == "Schema" else 0,
-            0,
-            1 if bp_schema == "ETag schema" else 0,
-        ):
+        with assert_counters(0, 1 if etag_schema else 0):
             response = client.delete(
                 f"/test/{item_1_id}", headers={"If-Match": item_etag}
             )
         assert response.status_code == 412
 
         # DELETE with correct ETag: No Content
-        with assert_counters(
-            0,
-            1 if bp_schema == "Schema" else 0,
-            0,
-            1 if bp_schema == "ETag schema" else 0,
-        ):
+        with assert_counters(0, 1 if etag_schema else 0):
             response = client.delete(
                 f"/test/{item_1_id}", headers={"If-Match": new_item_etag}
             )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -27,20 +27,20 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
     blp = Blueprint("test", __name__, url_prefix="/test")
 
     @blp.route("/")
+    @blp.etag
     class Resource(MethodView):
-        @blp.etag
         @blp.response(200, DocSchema(many=True))
         @blp.paginate(Page)
         def get(self):
             return collection.items
 
-        @blp.etag
         @blp.arguments(DocSchema)
         @blp.response(201, DocSchema)
         def post(self, new_item):
             return collection.post(new_item)
 
     @blp.route("/<int:item_id>")
+    @blp.etag
     class ResourceById(MethodView):
         def _get_item(self, item_id):
             try:
@@ -48,12 +48,10 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
             except ItemNotFound:
                 abort(404)
 
-        @blp.etag
         @blp.response(200, DocSchema)
         def get(self, item_id):
             return self._get_item(item_id)
 
-        @blp.etag
         @blp.arguments(DocSchema)
         @blp.response(200, DocSchema)
         def put(self, new_item, item_id):
@@ -62,7 +60,6 @@ def implicit_data_and_schema_etag_blueprint(collection, schemas):
             blp.check_etag(item, DocSchema)
             return collection.put(item_id, new_item)
 
-        @blp.etag
         @blp.response(204)
         def delete(self, item_id):
             item = self._get_item(item_id)
@@ -86,8 +83,8 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
     blp = Blueprint("test", __name__, url_prefix="/test")
 
     @blp.route("/")
+    @blp.etag
     class Resource(MethodView):
-        @blp.etag
         @blp.response(200, DocSchema(many=True))
         @blp.paginate()
         def get(self, pagination_parameters):
@@ -98,7 +95,6 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
                 pagination_parameters.first_item : pagination_parameters.last_item + 1
             ]
 
-        @blp.etag
         @blp.arguments(DocSchema)
         @blp.response(201, DocSchema)
         def post(self, new_item):
@@ -107,6 +103,7 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
             return collection.post(new_item)
 
     @blp.route("/<int:item_id>")
+    @blp.etag
     class ResourceById(MethodView):
         def _get_item(self, item_id):
             try:
@@ -114,7 +111,6 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
             except ItemNotFound:
                 abort(404)
 
-        @blp.etag
         @blp.response(200, DocSchema)
         def get(self, item_id):
             item = self._get_item(item_id)
@@ -122,7 +118,6 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
             blp.set_etag(item["db_field"])
             return item
 
-        @blp.etag
         @blp.arguments(DocSchema)
         @blp.response(200, DocSchema)
         def put(self, new_item, item_id):
@@ -134,7 +129,6 @@ def explicit_data_no_schema_etag_blueprint(collection, schemas):
             blp.set_etag(new_item["db_field"])
             return new_item
 
-        @blp.etag
         @blp.response(204)
         def delete(self, item_id):
             item = self._get_item(item_id)


### PR DESCRIPTION
This is an attempt to simplify the ETag feature.

The "compute ETag with API response data using another schema" case is a leftover from the past and I don't think it is relevant. Removing it reduces API surface, allows to simplify the code and makes the feature more understandable by the user.

Also, this change makes `_generate_etag` easier to override for users not happy with its implementation (see #393).

Finally, allow `etag` decorator to be applied to a whole `MethodView` at once (introducing `_decorate_view_func_or_method_view` that may be useful for #280 and #311).

There are still things I would like to improve in the ETag feature (like the fact that it is still not completely decoupled from the response decorator), but this iteration should be an improvement by itself.

