### PR TITLE
Require marshmallow >= 3.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     install_requires=[
         "werkzeug>=2.0,<3",
         "flask>=2.0,<3",
-        "marshmallow>=3.13.0,<4",
+        "marshmallow>=3.18.0,<4",
         "webargs>=8.0.0,<9",
         "apispec[marshmallow]>=6.0.0,<7",
     ],


### PR DESCRIPTION
It is required implicitly by apispec 6 but let's make it explicit to users.