### PR TITLE
Allow selecting location to load paginations parameters from

### DIFF
--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -101,6 +101,9 @@ specific range of data by passing query arguments:
 
 The view function gets default values for the pagination parameters, as well as
 a maximum value for ``page_size``.
+If the parameters are coming from another source (for example JSON), you can set the location from which to load
+them via the ``location`` argument to the decorator
+
 
 Those default values are defined as
 

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -147,13 +147,14 @@ class PaginationMixin:
     # Can be overridden to provide custom defaults
     DEFAULT_PAGINATION_PARAMETERS = {"page": 1, "page_size": 10, "max_page_size": 100}
 
-    def paginate(self, pager=None, *, page=None, page_size=None, max_page_size=None):
+    def paginate(self, pager=None, *, page=None, page_size=None, max_page_size=None, location="query"):
         """Decorator adding pagination to the endpoint
 
         :param Page pager: Page class used to paginate response data
         :param int page: Default requested page number (default: 1)
         :param int page_size: Default requested page size (default: 10)
         :param int max_page_size: Maximum page size (default: 100)
+        :param str location: Where to look for the page params (default: query)
 
         If a :class:`Page <Page>` class is provided, it is used to paginate the
         data returned by the view function, typically a lazy database cursor.
@@ -188,7 +189,7 @@ class PaginationMixin:
             def wrapper(*args, **kwargs):
 
                 page_params = self.PAGINATION_ARGUMENTS_PARSER.parse(
-                    page_params_schema, request, location="query"
+                    page_params_schema, request, location=location
                 )
 
                 # Pagination in resource code: inject page_params as kwargs

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -426,3 +426,26 @@ class TestPagination:
             query_string={"page": 2, "page_size": 20, "arg1": "Test", "arg2": 12},
         )
         assert response.json == list(range(20, 30))
+
+    def test_pagination_location(self, app, schemas):
+        api = Api(app)
+        blp = Blueprint("test", __name__, url_prefix="/test")
+
+        @blp.post("/")
+        @blp.arguments(schemas.QueryArgsSchema)
+        @blp.response(200)
+        @blp.paginate(Page, location="json")
+        def func(query_args):
+            assert query_args["arg1"] == "Test"
+            assert query_args["arg2"] == 12
+            return range(30)
+
+        api.register_blueprint(blp)
+        client = app.test_client()
+
+        # Pagination params in query string: OK
+        response = client.post(
+            "/test/",
+            json={"page": 2, "page_size": 20, "arg1": "Test", "arg2": 12},
+        )
+        assert response.json == list(range(20, 30))


### PR DESCRIPTION
Hey there

For our use case we have a search with some complex filters that are hard to represent as GET parameters (we could use JSON in the query params but it's not supported either afaik so going with the simplest fix) so we use POST.
However, the PaginationMixin hardcodes the location from which to extract the params. This PR just allows the user to select another location at the decorator level.