### PR TITLE
support dict as Schema

### DIFF
--- a/flask_smorest/arguments.py
+++ b/flask_smorest/arguments.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from functools import wraps
 import http
 
+import marshmallow as ma
 from webargs.flaskparser import FlaskParser
 
 from .utils import deepupdate
@@ -28,8 +29,8 @@ class ArgumentsMixin:
     ):
         """Decorator specifying the schema used to deserialize parameters
 
-        :param type|Schema schema: Marshmallow ``Schema`` class or instance
-            used to deserialize and validate the argument.
+        :param type|Schema|dict schema: Marshmallow ``Schema`` class or instance
+            or dict used to deserialize and validate the argument.
         :param str location: Location of the argument.
         :param str content_type: Content type of the argument.
             Should only be used in conjunction with ``json``, ``form`` or
@@ -56,6 +57,8 @@ class ArgumentsMixin:
 
         See :doc:`Arguments <arguments>`.
         """
+        if isinstance(schema, dict):
+            schema = ma.Schema.from_dict(schema)
         # At this stage, put schema instance in doc dictionary. Il will be
         # replaced later on by $ref or json.
         parameters = {

--- a/flask_smorest/utils.py
+++ b/flask_smorest/utils.py
@@ -2,6 +2,7 @@
 
 from collections import abc
 
+import marshmallow as ma
 from werkzeug.datastructures import Headers
 from flask import g
 from apispec.utils import trim_docstring, dedent
@@ -31,9 +32,16 @@ def remove_none(mapping):
 def resolve_schema_instance(schema):
     """Return schema instance for given schema (instance or class).
 
-    :param type|Schema schema: marshmallow.Schema instance or class
+    :param type|Schema|dict schema: marshmallow.Schema instance or class or dict
     :return: schema instance of given schema
     """
+
+    # this dict may be used to document a file response, no a schema dict
+    if isinstance(schema, dict) and all(
+        [isinstance(v, (type, ma.fields.Field)) for v in schema.values()]
+    ):
+        schema = ma.Schema.from_dict(schema)
+
     return schema() if isinstance(schema, type) else schema
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,11 @@ def schemas():
         error_id = ma.fields.Str()
         text = ma.fields.Str()
 
-    return namedtuple("Model", ("DocSchema", "QueryArgsSchema", "ClientErrorSchema"))(
-        DocSchema, QueryArgsSchema, ClientErrorSchema
-    )
+    DictSchema = {
+        "item_id": ma.fields.Int(dump_only=True),
+        "field": ma.fields.Int(attribute="db_field"),
+    }
+
+    return namedtuple(
+        "Model", ("DocSchema", "QueryArgsSchema", "ClientErrorSchema", "DictSchema")
+    )(DocSchema, QueryArgsSchema, ClientErrorSchema, DictSchema)


### PR DESCRIPTION
Sometimes it's not necessary to define a schema class for each API.

This PR support `@blp.arguments({'arg': ma.fields.Str()})` and `@blp.response(200, {'arg': ma.fields.Str()})`

close #180  #238 