### PR TITLE
Allow multiple responses with same status code

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -417,28 +417,29 @@ class TestCustomExamples:
                 if operation:
                     success_status_codes = doc_info.get("success_status_codes", [])
                     for success_status_code in success_status_codes:
-                        response = operation.get("responses", {}).get(
+                        responses = operation.get("responses", {}).get(
                             success_status_code
                         )
-                        if response is not None:
-                            if "schema" in response:
-                                schema = response["schema"]
-                                response["schema"] = type(
-                                    "Wrap" + schema.__class__.__name__,
-                                    (ma.Schema,),
-                                    {"data": ma.fields.Nested(schema)},
-                                )
-                                if "pagination" in doc_info:
+                        if responses is not None:
+                            for response in responses:
+                                if "schema" in response:
                                     schema = response["schema"]
                                     response["schema"] = type(
-                                        "Pagination" + schema.__name__,
-                                        (schema,),
-                                        {
-                                            "pagination": ma.fields.Nested(
-                                                PaginationMetadataSchema
-                                            )
-                                        },
+                                        "Wrap" + schema.__class__.__name__,
+                                        (ma.Schema,),
+                                        {"data": ma.fields.Nested(schema)},
                                     )
+                                    if "pagination" in doc_info:
+                                        schema = response["schema"]
+                                        response["schema"] = type(
+                                            "Pagination" + schema.__name__,
+                                            (schema,),
+                                            {
+                                                "pagination": ma.fields.Nested(
+                                                    PaginationMetadataSchema
+                                                )
+                                            },
+                                        )
                 return super(WrapperBlueprint, WrapperBlueprint)._prepare_response_doc(
                     doc, doc_info, spec=spec, **kwargs
                 )


### PR DESCRIPTION
This PR allows the definition of multiple responses with the same status code (previous to this PR, the outermost response decorator would override the others).

```py
        @blp.route("/")
        @blp.response(200, schema="JSONDocSchema")
        @blp.alt_response(200, schema="HTMLDocSchema", content_type="text/html")
        @blp.alt_response(200, schema="CSVDocSchema", content_type="text/csv")
        def func():
            pass
```