### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: '3.7', python: '3.7', tox: py37}
+          - {name: '3.8', python: '3.8', tox: py38}
           - {name: '3.11', python: '3.11', tox: py311}
     steps:
       - uses: actions/checkout@v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v3.3.1
   hooks:
   - id: pyupgrade
-    args: [--py37-plus]
+    args: [--py38-plus]
 - repo: https://github.com/psf/black
   rev: 23.3.0
   hooks:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Flask",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -65,7 +64,7 @@ setup(
     package_data={
         "": ["spec/templates/*"],
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "werkzeug>=2.0,<3",
         "flask>=2.0,<3",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py37,py38,py39,py310,py311
+envlist = lint,py38,py39,py310,py311
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.7 is [EOL in 2 months](https://endoflife.date/python) and was just dropped by werkzeug/flask.