### PR TITLE
#541 Fix order of automatic path parameters extracted from Flask route to be consistently left to right

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,4 @@ Contributors (chronological)
 - Dmitry Erlikh `@derlikh-smart <https://github.com/derlikh-smart>`_
 - 0x78f1935 `@0x78f1935 <https://github.com/0x78f1935>`_
 - One Codex, Inc. `@onecodex <https://github.com/onecodex>`_
+- Dorian Hoxha `@ddorian <https://github.com/ddorian>`_

--- a/flask_smorest/spec/plugins.py
+++ b/flask_smorest/spec/plugins.py
@@ -110,7 +110,11 @@ class FlaskPlugin(BasePlugin):
     def rule_to_params(self, rule):
         """Get parameters from flask Rule"""
         params = []
-        for argument in [a for a in rule.arguments if a not in rule.defaults]:
+        for argument in [
+            a
+            for is_dynamic, a in rule._trace
+            if is_dynamic is True and a not in rule.defaults
+        ]:
             param = {
                 "in": "path",
                 "name": argument,

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -36,6 +36,27 @@ class TestAPISpec:
             assert "consumes" not in spec
 
     @pytest.mark.parametrize("openapi_version", ["2.0", "3.0.2"])
+    def test_apispec_correct_path_parameters_ordering(self, app, openapi_version):
+        """Test path parameters are sorted from left to right.
+
+        If this test is flaky it's considered a failure.
+        """
+        app.config["OPENAPI_VERSION"] = openapi_version
+        api = Api(app)
+
+        blp = Blueprint("pets", "pets", url_prefix="/pets")
+
+        @blp.route("/project/<project_id>/upload/<part_id>/complete")
+        def do_nothing():
+            return
+
+        api.register_blueprint(blp)
+
+        sorted_params = list(api.spec.to_dict()["paths"].values())[0]["parameters"]
+        assert sorted_params[0]["name"] == "project_id"
+        assert sorted_params[1]["name"] == "part_id"
+
+    @pytest.mark.parametrize("openapi_version", ["2.0", "3.0.2"])
     def test_apispec_lazy_registers_error_responses(self, app, openapi_version):
         """Test error responses are registered"""
         app.config["OPENAPI_VERSION"] = openapi_version


### PR DESCRIPTION
Fixes #541 