### PR TITLE
Biginteger field

### DIFF
--- a/flask_smorest/fields.py
+++ b/flask_smorest/fields.py
@@ -13,3 +13,18 @@ class Upload(ma.fields.Field):
     def __init__(self, format="binary", **kwargs):
         self.format = format
         super().__init__(**kwargs)
+
+
+class BigInteger(ma.fields.Integer):
+    """A bigint field."""
+
+    def _validated(self, value):
+        """Validate that the number is inside 64bit bigint."""
+        new_value = super()._validated(value)
+        invalid_bigint = (new_value > (2**63 - 1)) or (new_value < (-(2**63) + 1))
+        if invalid_bigint:
+            raise self.make_error("invalid_bigint", input=value)
+        return new_value
+
+
+BigInteger.default_error_messages["invalid_bigint"] = "Number not valid bigint."


### PR DESCRIPTION
I was using https://github.com/schemathesis/schemathesis to test my openapi, and the first thing it did was to send a out-of-range bigint, that was accepted by python, but actually errored in PostgreSQL (`sqlalchemy.exc.DataError: (psycopg.errors.NumericValueOutOfRange) bigint out of range`).

So I created a BigInteger field that checks that.