### PR TITLE
Fix OpenAPI docs generation to include missing response headers when pagination is used

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Contributors (chronological)
 - 0x78f1935 `@0x78f1935 <https://github.com/0x78f1935>`_
 - One Codex, Inc. `@onecodex <https://github.com/onecodex>`_
 - Dorian Hoxha `@ddorian <https://github.com/ddorian>`_
+- drcpu `@drcpu-github <https://github.com/drcpu-github>`_

--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -276,11 +276,13 @@ class PaginationMixin:
 
         Override this to document custom pagination metadata
         """
-        resp_doc["headers"] = {
-            self.PAGINATION_HEADER_NAME: "PAGINATION"
-            if spec.openapi_version.major >= 3
-            else PAGINATION_HEADER
-        }
+        resp_doc.setdefault("headers", {}).update(
+            {
+                self.PAGINATION_HEADER_NAME: "PAGINATION"
+                if spec.openapi_version.major >= 3
+                else PAGINATION_HEADER
+            }
+        )
 
     def _prepare_pagination_doc(self, doc, doc_info, *, spec, **kwargs):
         operation = doc_info.get("pagination")


### PR DESCRIPTION
PR for issue #578.

Added the code I showed in the issue and a simple test to show that it works. Not sure if you expect more from a test than this, but let me know.