### PR TITLE
Support python 3.12

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - {name: '3.8', python: '3.8', tox: py38}
-          - {name: '3.11', python: '3.11', tox: py311}
+          - {name: '3.12', python: '3.12', tox: py312}
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-python@v4.3.0

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Contributors (chronological)
 - One Codex, Inc. `@onecodex <https://github.com/onecodex>`_
 - Dorian Hoxha `@ddorian <https://github.com/ddorian>`_
 - drcpu `@drcpu-github <https://github.com/drcpu-github>`_
+- JAEGYUN JUNG `@tgoddessana <https://github.com/TGoddessana>`_

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
     ],
     keywords=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py38,py39,py310,py311
+envlist = lint,py38,py39,py310,py311,py312
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
### Support Python 3.12

- added tox test environment 3.12
- changed github workflows run test with python3.8 to python3.12
- added classifires in `setup.py`

Since all the test code passed on python3.12, I just modified the CI to test python3.12.