### PR TITLE
Require Flask 3 and Werkzeug 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "werkzeug>=2.0.1,<4",
-        "flask>=2.0.1,<4",
+        "werkzeug>=3.0.1,<4",
+        "flask>=3.0.2,<4",
         "marshmallow>=3.18.0,<4",
         "webargs>=8.0.0,<9",
         "apispec[marshmallow]>=6.0.0,<7",


### PR DESCRIPTION
This shouldn't be an issue as there are few breaking changes, and it saves us from testing both Flask 2 and 3.