### PR TITLE
Improve errorhandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-.idea/
+#.idea/

--- a/src/flask_smorest/__init__.py
+++ b/src/flask_smorest/__init__.py
@@ -1,12 +1,11 @@
 """Api extension initialization"""
 
-from webargs.flaskparser import abort  # noqa
-
-from .spec import APISpecMixin
 from .blueprint import Blueprint  # noqa
-from .pagination import Page  # noqa
 from .error_handler import ErrorHandlerMixin
+from .exceptions import abort  # noqa
 from .globals import current_api  # noqa
+from .pagination import Page  # noqa
+from .spec import APISpecMixin
 from .utils import PrefixedMappingProxy, normalize_config_prefix
 
 

--- a/src/flask_smorest/error_handler.py
+++ b/src/flask_smorest/error_handler.py
@@ -1,8 +1,8 @@
 """Exception handler"""
 
-from werkzeug.exceptions import HTTPException
-
 import marshmallow as ma
+
+from flask_smorest.exceptions import ApiException
 
 
 class ErrorSchema(ma.Schema):
@@ -28,23 +28,18 @@ class ErrorHandlerMixin:
 
         This method registers a default error handler for ``HTTPException``.
         """
-        self._app.register_error_handler(HTTPException, self.handle_http_exception)
+        self._app.register_error_handler(ApiException, self.handle_http_exception)
 
     def handle_http_exception(self, error):
         """Return a JSON response containing a description of the error
 
-        This method is registered at app init to handle ``HTTPException``.
+        This method is registered at app init to handle ``ApiException``.
 
-        - When ``abort`` is called in the code, an ``HTTPException`` is
+        - When ``abort`` is called in the code, an ``ApiException`` is
           triggered and Flask calls this handler.
 
         - When an exception is not caught in a view, Flask makes it an
           ``InternalServerError`` and calls this handler.
-
-        flask-smorest republishes webargs's
-        :func:`abort <webargs.flaskparser.abort>`. This ``abort`` allows the
-        caller to pass kwargs and stores them in ``exception.data`` so that the
-        error handler can use them to populate the response payload.
 
         Extra information expected by this handler:
 

--- a/src/flask_smorest/exceptions.py
+++ b/src/flask_smorest/exceptions.py
@@ -7,11 +7,151 @@ class FlaskSmorestError(Exception):
     """Generic flask-smorest exception"""
 
 
+# Non-API exceptions
 class MissingAPIParameterError(FlaskSmorestError):
     """Missing API parameter"""
 
 
-class NotModified(wexc.HTTPException, FlaskSmorestError):
+class CurrentApiNotAvailableError(FlaskSmorestError):
+    """`current_api` not available"""
+
+
+# API exceptions
+class ApiException(wexc.HTTPException, FlaskSmorestError):
+    """A generic API error."""
+
+    @classmethod
+    def get_exception_by_code(cls, code):
+        for exception in cls.__subclasses__():
+            if exception.code == code:
+                return exception
+        return InternalServerError
+
+
+class BadRequest(wexc.BadRequest, ApiException):
+    """Bad request"""
+
+
+class Unauthorized(wexc.Unauthorized, ApiException):
+    """Unauthorized access"""
+
+
+class Forbidden(wexc.Forbidden, ApiException):
+    """Forbidden access"""
+
+
+class NotFound(wexc.NotFound, ApiException):
+    """Resource not found"""
+
+
+class MethodNotAllowed(wexc.MethodNotAllowed, ApiException):
+    """Method not allowed"""
+
+
+class NotAcceptable(wexc.NotAcceptable, ApiException):
+    """Not acceptable"""
+
+
+class RequestTimeout(wexc.RequestTimeout, ApiException):
+    """Request timeout"""
+
+
+class Conflict(wexc.Conflict, ApiException):
+    """Conflict"""
+
+
+class Gone(wexc.Gone, ApiException):
+    """Resource gone"""
+
+
+class LengthRequired(wexc.LengthRequired, ApiException):
+    """Length required"""
+
+
+class PreconditionFailed(wexc.PreconditionFailed, ApiException):
+    """Etag required and wrong ETag provided"""
+
+
+class RequestEntityTooLarge(wexc.RequestEntityTooLarge, ApiException):
+    """Request entity too large"""
+
+
+class RequestURITooLarge(wexc.RequestURITooLarge, ApiException):
+    """Request URI too large"""
+
+
+class UnsupportedMediaType(wexc.UnsupportedMediaType, ApiException):
+    """Unsupported media type"""
+
+
+class RequestedRangeNotSatisfiable(wexc.RequestedRangeNotSatisfiable, ApiException):
+    """Requested range not satisfiable"""
+
+
+class ExpectationFailed(wexc.ExpectationFailed, ApiException):
+    """Expectation failed"""
+
+
+class ImATeapot(wexc.ImATeapot, ApiException):
+    """I'm a teapot"""
+
+
+class UnprocessableEntity(wexc.UnprocessableEntity, ApiException):
+    """Unprocessable entity"""
+
+
+class Locked(wexc.Locked, ApiException):
+    """Locked"""
+
+
+class FailedDependency(wexc.FailedDependency, ApiException):
+    """Failed dependency"""
+
+
+class PreconditionRequired(wexc.PreconditionRequired, ApiException):
+    """Etag required but missing"""
+
+    # Overriding description as we don't provide If-Unmodified-Since
+    description = 'This request is required to be conditional; try using "If-Match".'
+
+
+class TooManyRequests(wexc.TooManyRequests, ApiException):
+    """Too many requests"""
+
+
+class RequestHeaderFieldsTooLarge(wexc.RequestHeaderFieldsTooLarge, ApiException):
+    """Request header fields too large"""
+
+
+class UnavailableForLegalReasons(wexc.UnavailableForLegalReasons, ApiException):
+    """Unavailable for legal reasons"""
+
+
+class InternalServerError(wexc.InternalServerError, ApiException):
+    """Internal server error"""
+
+
+class NotImplemented(wexc.NotImplemented, ApiException):
+    """Not implemented"""
+
+
+class BadGateway(wexc.BadGateway, ApiException):
+    """Bad gateway"""
+
+
+class ServiceUnavailable(wexc.ServiceUnavailable, ApiException):
+    """Service unavailable"""
+
+
+class GatewayTimeout(wexc.GatewayTimeout, ApiException):
+    """Gateway timeout"""
+
+
+class HTTPVersionNotSupported(wexc.HTTPVersionNotSupported, ApiException):
+    """HTTP version not supported"""
+
+
+class NotModified(ApiException):
     """Resource was not modified (Etag is unchanged)
 
     Exception created to compensate for a lack in Werkzeug (and Flask)
@@ -21,16 +161,12 @@ class NotModified(wexc.HTTPException, FlaskSmorestError):
     description = "Resource not modified since last request."
 
 
-class PreconditionRequired(wexc.PreconditionRequired, FlaskSmorestError):
-    """Etag required but missing"""
-
-    # Overriding description as we don't provide If-Unmodified-Since
-    description = 'This request is required to be conditional; try using "If-Match".'
-
-
-class PreconditionFailed(wexc.PreconditionFailed, FlaskSmorestError):
-    """Etag required and wrong ETag provided"""
-
-
-class CurrentApiNotAvailableError(FlaskSmorestError):
-    """`current_api` not available"""
+def abort(http_status_code, exc=None, **kwargs):
+    try:
+        raise ApiException.get_exception_by_code(http_status_code)
+    except ApiException as err:
+        err.data = kwargs
+        err.exc = exc
+        raise err
+    except Exception as err:
+        raise err


### PR DESCRIPTION
## There are a few issues... (shouldn't be merged yet)

1. The `abort(code)` works, but raise ApiException() doesn't work with the json response, in my opinion, raising an `ApiException` should automatically result in a 500 json handling, but it's not.
The `flask_abort()` and `api_abort()` use cases work anyway... I just want to handle them elegantly. (What should be the behavior if the user raises `ApiException()` instead of `flask_smorest.abort()`?)

2. I looked at the method you mentioned in the original issue(re-define all werkzeug exceptions), and my guess is that since we are inheriting and defining some exceptions from Flask-Smorest, it would be better to explicitly inherit them all, even if it makes the code a bit longer (I'd love to hear your opinion).
