### PR TITLE
Update __init__.py

### DIFF
--- a/src/flask_smorest/__init__.py
+++ b/src/flask_smorest/__init__.py
@@ -1,5 +1,7 @@
 """Api extension initialization"""
 
+from typing import Union
+from werkzeug.utils import import_string
 from webargs.flaskparser import abort  # noqa
 
 from .spec import APISpecMixin
@@ -41,6 +43,7 @@ class Api(APISpecMixin, ErrorHandlerMixin):
     """
 
     def __init__(self, app=None, *, spec_kwargs=None, config_prefix=""):
+        self._routes = []
         self._app = app
         self._spec_kwargs = spec_kwargs or {}
         self.config_prefix = normalize_config_prefix(config_prefix)
@@ -83,7 +86,11 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         # Register error handlers
         self._register_error_handlers()
 
-    def register_blueprint(self, blp, *, parameters=None, **options):
+        for blp, parameters, options in self._routes:
+            self.register_blueprint(blp, parameters=parameters, **options)
+        
+
+    def register_blueprint(self, blp: Union[Blueprint, str], *, parameters=None, **options):
         """Register a blueprint in the application
 
         Also registers documentation for the blueprint/resource
@@ -96,20 +103,26 @@ class Api(APISpecMixin, ErrorHandlerMixin):
 
         Must be called after app is initialized.
         """
-        blp_name = options.get("name", blp.name)
+        if isinstance(blp, str):
+            blp = import_string(blp)
 
-        self._app.extensions["flask-smorest"]["blp_name_to_api"][blp_name] = self
-
-        self._app.register_blueprint(blp, **options)
-
-        # Register views in API documentation for this resource
-        blp.register_views_in_doc(
-            self,
-            self._app,
-            self.spec,
-            name=blp_name,
-            parameters=parameters,
-        )
-
-        # Add tag relative to this resource to the global tag list
-        self.spec.tag({"name": blp_name, "description": blp.description})
+        if self._app:        
+            blp_name = options.get("name", blp.name)
+    
+            self._app.extensions["flask-smorest"]["blp_name_to_api"][blp_name] = self
+    
+            self._app.register_blueprint(blp, **options)
+    
+            # Register views in API documentation for this resource
+            blp.register_views_in_doc(
+                self,
+                self._app,
+                self.spec,
+                name=blp_name,
+                parameters=parameters,
+            )
+    
+            # Add tag relative to this resource to the global tag list
+            self.spec.tag({"name": blp_name, "description": blp.description})
+        else:
+            self._routes.append((blp, parameters, options))

--- a/src/flask_smorest/__init__.py
+++ b/src/flask_smorest/__init__.py
@@ -1,14 +1,16 @@
 """Api extension initialization"""
 
 from typing import Union
+
 from werkzeug.utils import import_string
+
 from webargs.flaskparser import abort  # noqa
 
-from .spec import APISpecMixin
 from .blueprint import Blueprint  # noqa
-from .pagination import Page  # noqa
 from .error_handler import ErrorHandlerMixin
 from .globals import current_api  # noqa
+from .pagination import Page  # noqa
+from .spec import APISpecMixin
 from .utils import PrefixedMappingProxy, normalize_config_prefix
 
 
@@ -88,9 +90,10 @@ class Api(APISpecMixin, ErrorHandlerMixin):
 
         for blp, parameters, options in self._routes:
             self.register_blueprint(blp, parameters=parameters, **options)
-        
 
-    def register_blueprint(self, blp: Union[Blueprint, str], *, parameters=None, **options):
+    def register_blueprint(
+        self, blp: Union[Blueprint, str], *, parameters=None, **options
+    ):
         """Register a blueprint in the application
 
         Also registers documentation for the blueprint/resource
@@ -106,13 +109,13 @@ class Api(APISpecMixin, ErrorHandlerMixin):
         if isinstance(blp, str):
             blp = import_string(blp)
 
-        if self._app:        
+        if self._app:
             blp_name = options.get("name", blp.name)
-    
+
             self._app.extensions["flask-smorest"]["blp_name_to_api"][blp_name] = self
-    
+
             self._app.register_blueprint(blp, **options)
-    
+
             # Register views in API documentation for this resource
             blp.register_views_in_doc(
                 self,
@@ -121,7 +124,7 @@ class Api(APISpecMixin, ErrorHandlerMixin):
                 name=blp_name,
                 parameters=parameters,
             )
-    
+
             # Add tag relative to this resource to the global tag list
             self.spec.tag({"name": blp_name, "description": blp.description})
         else:


### PR DESCRIPTION

**The original**
    
```
   _The first method：_
    from blueprint import bp
    api = Api(app)
    api.register_bluepirnt(bp)
```
    
    _The second method_
    form blueprint import bp
    api = Api()
    # # Must call init_app before registering the API blueprint
    api.init_app(app)
    
    api.register_blueprint(bp)    
    
**After the update, there are no issues with the above two writing methods, and the following new usage methods will continue to be added**
    
    api = Api()
    
    from blueprint import bp
    api.register_blueprint(bp)
    # #Or register as a string
    api.register_blueprint('blueprint.bp')
    
    # # last
    api.init_app(app)
