### PR TITLE
Require marshmallow 3.24

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -242,23 +242,9 @@ schema `properties`. Although objects are not ordered in JSON, OpenAPI
 graphical interfaces tend to respect the order in which the `properties` are
 defined in the ``properties`` object in the specification file.
 
-When using an ordererd ``Schema``, the fields definition order is preserved
-when generating the specification file and the `properties` are displayed in
-that order.
+``Schema`` classes keep fields in declaration order, and this order is preserved when
+generating the specification file: the `properties` are displayed in that order.
 
-This is typically done in a base class:
-
-.. code-block:: python
-    :emphasize-lines: 2,3
-
-    class MyBaseSchema(ma.Schema):
-        class Meta:
-            ordered = True
-
-
-    class User(MyBaseSchema):
-        name = ma.fields.String()
-        surname = ma.fields.String()
 
 Serve the OpenAPI Documentation
 -------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.9"
 dependencies = [
   "werkzeug>=3.0.1,<4",
   "flask>=3.0.2,<4",
-  "marshmallow>=3.18.0,<4",
+  "marshmallow>=3.24.1,<4",
   "webargs>=8.0.0,<9",
   "apispec[marshmallow]>=6.0.0,<7",
 ]
@@ -50,7 +50,7 @@ tests = [
   "coverage==7.6.10",
   "werkzeug==3.1.3",
   "flask==3.1.0",
-  "marshmallow==3.23.2",
+  "marshmallow==3.24.1",
   "webargs==8.6.0",
   "apispec==6.8.0",
   "PyYAML==6.0.2",

--- a/src/flask_smorest/pagination.py
+++ b/src/flask_smorest/pagination.py
@@ -59,7 +59,6 @@ def _pagination_parameters_schema_factory(def_page, def_page_size, def_max_page_
         """Deserializes pagination params into PaginationParameters"""
 
         class Meta:
-            ordered = True
             unknown = ma.EXCLUDE
 
         page = ma.fields.Integer(
@@ -126,9 +125,6 @@ class PaginationMetadataSchema(ma.Schema):
     page = ma.fields.Int()
     previous_page = ma.fields.Int()
     next_page = ma.fields.Int()
-
-    class Meta:
-        ordered = True
 
 
 PAGINATION_HEADER = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ def schemas():
 
     class QueryArgsSchema(ma.Schema):
         class Meta:
-            ordered = True
             unknown = ma.EXCLUDE
 
         arg1 = ma.fields.String()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -546,7 +546,7 @@ class TestApi:
                 return json.dumps(obj, **kwargs, cls=CustomJSONEncoder)
 
         class CustomSchema(ma.Schema):
-            custom_field = ma.fields.Field(load_default=CustomType())
+            custom_field = ma.fields.Raw(load_default=CustomType())
 
         app.config["OPENAPI_VERSION"] = openapi_version
         app.json = CustomJsonProvider(app)


### PR DESCRIPTION
This provides a little cleanup and is a first step towards supporting marshmallow 4.0.